### PR TITLE
Add FastAPI Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -458,3 +458,11 @@ $RECYCLE.BIN/
 
 # Pycharm config
 /.idea/
+
+### VisualStudioCode ###
+.vscode/*
+.vscode/settings.json
+.vscode/tasks.json
+.vscode/launch.json
+.vscode/extensions.json
+.vscode/*.code-snippets

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Jinja2 fragments
 
-Jinja2 Fragments allows rendering individual blocks from 
+Jinja2 Fragments allows rendering individual blocks from
 [Jinja2 templates](https://palletsprojects.com/p/jinja/). This library was created
-to enable the pattern of 
+to enable the pattern of
 [Template Fragments](https://htmx.org/essays/template-fragments/) with Jinja2. It's a
 great pattern if you are using [HTMX](https://htmx.org/) or some other library that
 leverages fetching partial HTML.
@@ -13,7 +13,7 @@ use the [include tag](https://jinja.palletsprojects.com/en/3.1.x/templates/#incl
 (or [Jinja Partials](https://github.com/mikeckennedy/jinja_partials)) on the wrapping
 template.
 
-With Jinja2 Fragments, following the 
+With Jinja2 Fragments, following the
 [Locality of Behavior](https://htmx.org/essays/locality-of-behaviour/) design principle
 you have a single file for both cases. See below for examples.
 
@@ -49,7 +49,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from jinja2_fragments import render_block
 
 environment = Environment(
-    loader=FileSystemLoader("my_templates"), 
+    loader=FileSystemLoader("my_templates"),
     autoescape=select_autoescape(("html", "jinja2"))
 )
 rendered_html = render_block(
@@ -103,7 +103,40 @@ async def full_page():
 async def only_content():
     return await render_block("page.html.jinja2", "content", magic_number=42)
 ```
+## Usage with FastAPI
 
+You can also use Jinja2 Fragments with FastAPI. FastAPI wraps Jinja `Environment` with the object `Jinja2Templates` and uses a `TemplateResponse` to create the HTML. Jinja2 Fragments uses the `Jinja2Templates` object to determine what response to send.
+
+For FastAPI, you use a decorator that takes the `Jinja2Templates` object as a positional parameter, and then you can then define the `block_name` as a key/value pair.
+
+Assuming the same template as the examples above:
+
+```py
+from fastapi import FastAPI
+from fastapi.requests import Request
+from fastapi.templating import Jinja2Templates
+
+app = FastAPI()
+
+templates = Jinja2Templates(directory="path/to/templates")
+
+@app.get("/full_page")
+@render_block(templates, magic_number=42)
+async def full_page(request: Request):
+    """No `block_name` given, so renders normally."""
+    return templates.TemplateResponse(
+        "page.html.jinja2",
+        {"request": request}
+    )
+
+@app.get("/only_content")
+@render_block(templates, block_name="content", magic_number=42)
+async def only_content(request: Request):
+    return templates.TemplateResponse(
+        "page.html.jinja2",
+        {"request": request}
+    )
+```
 ## How to collaborate
 
 This project uses pre-commit hooks to run black, isort, pyupgrade and flake8 on each commit. To have that running

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ use the [include tag](https://jinja.palletsprojects.com/en/3.1.x/templates/#incl
 template.
 
 With Jinja2 Fragments, following the
-[Locality of Behavior](https://htmx.org/essays/locality-of-behaviour/) design principle
+[Locality of Behavior](https://htmx.org/essays/locality-of-behaviour/) design principle,
 you have a single file for both cases. See below for examples.
 
 ## Install
@@ -105,36 +105,34 @@ async def only_content():
 ```
 ## Usage with FastAPI
 
-You can also use Jinja2 Fragments with FastAPI. FastAPI wraps Jinja `Environment` with the object `Jinja2Templates` and uses a `TemplateResponse` to create the HTML. Jinja2 Fragments uses the `Jinja2Templates` object to determine what response to send.
+You can also use Jinja2 Fragments with FastAPI. In this case, Jinja2 Fragments has a wrapper around the FastAPI `Jinja2Templates` object called `Jinja2Blocks`.
 
-For FastAPI, you use a decorator that takes the `Jinja2Templates` object as a positional parameter, and then you can then define the `block_name` as a key/value pair.
+It functions exactly the same, but allows you to include an optional parameter to the `TemplateResponse` that includes the `block_name` you want to render.
 
 Assuming the same template as the examples above:
 
 ```py
 from fastapi import FastAPI
 from fastapi.requests import Request
-from fastapi.templating import Jinja2Templates
+from jinja2_fragments.fastapi import Jinja2Blocks
 
 app = FastAPI()
 
-templates = Jinja2Templates(directory="path/to/templates")
+templates = Jinja2Blocks(directory="path/to/templates")
 
 @app.get("/full_page")
-@render_block(templates, magic_number=42)
 async def full_page(request: Request):
-    """No `block_name` given, so renders normally."""
     return templates.TemplateResponse(
         "page.html.jinja2",
-        {"request": request}
+        {"request": request, "magic_number": 42}
     )
 
 @app.get("/only_content")
-@render_block(templates, block_name="content", magic_number=42)
 async def only_content(request: Request):
     return templates.TemplateResponse(
         "page.html.jinja2",
-        {"request": request}
+        {"request": request, "magic_number": 42},
+        block_name="content"
     )
 ```
 ## How to collaborate

--- a/src/jinja2_fragments/fastapi.py
+++ b/src/jinja2_fragments/fastapi.py
@@ -1,0 +1,62 @@
+import typing
+from functools import wraps
+
+try:
+    from fastapi.templating import Jinja2Templates
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        "Install FastAPI before using jinja2_fragments.fastapi"
+    ) from e
+
+import jinja2_fragments
+
+
+class InvalidContextError(Exception):
+    pass
+
+
+def render_block(
+    jinja2templates: Jinja2Templates,
+    *,
+    block_name: typing.Optional[str] = None,
+    **context: typing.Any,
+):
+    """Renders the template's block from the template directory defined in
+    `jinja2templates` object, with the given context.
+
+    :param jinja2templates: the FastAPI `Jinja2Templates` object that mounts the
+    app template directory
+    :param block_name: the name of the block to be rendered
+    :param context: the variables that should be available in the context of the block
+    """
+
+    def inner(func):
+        env = jinja2templates.env  # Refers to Jinja's `Environment.get` object
+
+        @wraps(func)
+        async def response_method(*args, **kwargs):
+
+            # extract variables from FastAPI TemplateResponse
+            func_response = await func(*args, **kwargs)
+            func_context = func_response.context
+            template_name = func_response.template.name
+
+            # Combine context of TemplateResponse and method kwargs
+            context.update(func_context)
+
+            # Return FastAPI TemplateResponse if no block_name given
+            if not block_name:
+                return jinja2templates.TemplateResponse(template_name, context)
+
+            if isinstance(context, dict):
+                return jinja2_fragments.render_block(
+                    env, template_name, block_name, context
+                )
+            else:
+                raise InvalidContextError(
+                    f"Context of type {type(context)} is not valid. Expected dict."
+                )
+
+        return response_method
+
+    return inner

--- a/src/jinja2_fragments/fastapi.py
+++ b/src/jinja2_fragments/fastapi.py
@@ -1,62 +1,51 @@
 import typing
-from functools import wraps
 
 try:
-    from fastapi.templating import Jinja2Templates
+    from starlette.background import BackgroundTask
+    from starlette.templating import Jinja2Templates, _TemplateResponse
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
-        "Install FastAPI before using jinja2_fragments.fastapi"
+        "Install Starlette to use jinja2_fragments.fastapi"
     ) from e
 
-import jinja2_fragments
+from . import render_block
 
 
 class InvalidContextError(Exception):
     pass
 
 
-def render_block(
-    jinja2templates: Jinja2Templates,
-    *,
-    block_name: typing.Optional[str] = None,
-    **context: typing.Any,
-):
-    """Renders the template's block from the template directory defined in
-    `jinja2templates` object, with the given context.
+class Jinja2Blocks(Jinja2Templates):
+    def __init__(self, directory, **env_options):
+        super().__init__(directory, **env_options)
 
-    :param jinja2templates: the FastAPI `Jinja2Templates` object that mounts the
-    app template directory
-    :param block_name: the name of the block to be rendered
-    :param context: the variables that should be available in the context of the block
-    """
+    def TemplateResponse(
+        self,
+        name: str,
+        context: dict,
+        status_code: int = 200,
+        headers: typing.Optional[typing.Mapping[str, str]] = None,
+        media_type: typing.Optional[str] = None,
+        background: typing.Optional[BackgroundTask] = None,
+        *,
+        block_name: typing.Optional[str] = None,
+    ) -> typing.Union[_TemplateResponse, str]:
+        if "request" not in context:
+            raise ValueError('context must include a "request" key')
+        template = self.get_template(name)
 
-    def inner(func):
-        env = jinja2templates.env  # Refers to Jinja's `Environment.get` object
-
-        @wraps(func)
-        async def response_method(*args, **kwargs):
-
-            # extract variables from FastAPI TemplateResponse
-            func_response = await func(*args, **kwargs)
-            func_context = func_response.context
-            template_name = func_response.template.name
-
-            # Combine context of TemplateResponse and method kwargs
-            context.update(func_context)
-
-            # Return FastAPI TemplateResponse if no block_name given
-            if not block_name:
-                return jinja2templates.TemplateResponse(template_name, context)
-
-            if isinstance(context, dict):
-                return jinja2_fragments.render_block(
-                    env, template_name, block_name, context
-                )
-            else:
-                raise InvalidContextError(
-                    f"Context of type {type(context)} is not valid. Expected dict."
-                )
-
-        return response_method
-
-    return inner
+        if block_name:
+            return render_block(
+                self.env,
+                name,
+                block_name,
+                context,
+            )
+        return _TemplateResponse(
+            template,
+            context,
+            status_code=status_code,
+            headers=headers,
+            media_type=media_type,
+            background=background,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
 import pathlib
 
+import fastapi
 import flask
 import pytest
 import quart
+from fastapi.testclient import TestClient
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+from jinja2_fragments.fastapi import render_block as fastapi_render_block
 from jinja2_fragments.flask import render_block as flask_render_block
 from jinja2_fragments.quart import render_block as quart_render_block
 
@@ -141,3 +144,87 @@ def quart_app():
 @pytest.fixture(scope="session")
 def quart_client(quart_app):
     return quart_app.test_client()
+
+
+@pytest.fixture(scope="session")
+def fastapi_app():
+    from fastapi.templating import Jinja2Templates
+
+    _app = fastapi.FastAPI()
+
+    templates: Jinja2Templates = Jinja2Templates(
+        "tests/templates",
+        autoescape=select_autoescape(("html", "jinja2")),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+
+    @_app.get("/")
+    async def home():
+        return {"msg": "Hello World"}
+
+    @_app.get("/simple_page")
+    @fastapi_render_block(templates)
+    async def simple_page(
+        request: fastapi.requests.Request,
+    ):
+        """Decorator wraps around route method, but does not define a
+        `block_name` paramater, so the template renders normally.
+        """
+        page_to_render = "simple_page.html.jinja2"
+        return templates.TemplateResponse(page_to_render, {"request": request})
+
+    @_app.get("/simple_page_content")
+    @fastapi_render_block(templates, block_name="content")
+    async def simple_page_content(
+        request: fastapi.requests.Request,
+    ):
+        """Decorator wraps around route method and includes `block_name`
+        parameter, so will only render content within that block.
+        """
+        page_to_render = "simple_page.html.jinja2"
+        return templates.TemplateResponse(page_to_render, {"request": request})
+
+    @_app.get("/nested_content")
+    @fastapi_render_block(
+        templates,
+        block_name="content",
+        name=NAME,
+        lucky_number=LUCKY_NUMBER,
+    )
+    async def nested_content(request: fastapi.requests.Request):
+        """Decorator wraps around route method and includes `block_name`
+        plus parameters `name` and `lucky_number` which are passed
+        to the template. As a result, `content` will be rendered.
+        """
+        page_to_render = "nested_blocks_and_variables.html.jinja2"
+        return templates.TemplateResponse(
+            page_to_render,
+            {"request": request},
+        )
+
+    @_app.get("/nested_inner")
+    @fastapi_render_block(
+        templates,
+        block_name="inner",
+        name=NAME,
+        lucky_number=LUCKY_NUMBER,
+    )
+    async def nested_inner(request: fastapi.requests.Request):
+        """Decorator wraps around route method and includes `block_name`
+        plus parameters `name` and `lucky_number` which are passed
+        to the template. As a result, `inner` will be rendered.
+        """
+        page_to_render = "nested_blocks_and_variables.html.jinja2"
+        return templates.TemplateResponse(
+            page_to_render,
+            {"request": request},
+        )
+
+    return _app
+
+
+@pytest.fixture(scope="session")
+def fastapi_client(fastapi_app):
+    _client = TestClient(fastapi_app)
+    return _client

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,0 +1,7 @@
+from fastapi.testclient import TestClient
+
+
+def test_app(fastapi_app):
+    client = TestClient(fastapi_app)
+    response = client.get("/")
+    assert response.status_code == 200

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,7 +1,50 @@
-from fastapi.testclient import TestClient
+import re
 
 
-def test_app(fastapi_app):
-    client = TestClient(fastapi_app)
-    response = client.get("/")
-    assert response.status_code == 200
+class TestFastAPIRenderBlock:
+    """Tests each of the methods to make sure the html generated is
+    as expected. Removed whitespace and newline characters from html compare
+    to make it easier to compare output. I believe either encoding
+    or OS makes for odd variances otherwise.
+    """
+
+    def test_simple_page(
+        self,
+        fastapi_client,
+        get_html,
+    ):
+        response = fastapi_client.get("/simple_page")
+        html = get_html("simple_page.html")
+        assert html == response.text
+
+    def test_simple_page_content(
+        self,
+        fastapi_client,
+        get_html,
+    ):
+        response = fastapi_client.get("/simple_page_content")
+        response_text = response.text.replace('"', "").strip("\\n")
+        html = get_html("simple_page_content.html").strip("\n")
+        assert html == response_text
+
+    def test_nested_content(
+        self,
+        fastapi_client,
+        get_html,
+    ):
+        response = fastapi_client.get("/nested_content")
+        response_text = re.sub(r"[\s\"]*", "", response.text).replace("\\n", "")
+        html = get_html("nested_blocks_and_variables_content.html")
+        html = re.sub(r"[\s\"]*", "", html)
+        assert html == response_text
+
+    def test_nested_inner(
+        self,
+        fastapi_client,
+        get_html,
+    ):
+        response = fastapi_client.get("/nested_inner")
+        response_text = re.sub(r"[\s\"]*", "", response.text).replace("\\n", "")
+        html = get_html("nested_blocks_and_variables_inner.html")
+        html = re.sub(r"[\s\"]*", "", html)
+        assert html == response_text


### PR DESCRIPTION
I added FastAPI support (under `fastapi.py`). I generally tried to follow the same pattern as flask/quart, but have a slightly different approach.

With FastAPI, you have to declare a `Jinja2Templates` object, which is a subclass of the Jinja Environment class. This is declared outside of the route/view. And then, in order to render the template, you have to use a `Jinja2Templates` method. This is what it looks like ordinarily:

```py
from fastapi import FastAPI, Request
from fastapi.responses import HTMLResponse
from fastapi.templating import Jinja2Templates

app = FastAPI()

templates = Jinja2Templates(directory="templates")

@app.get("/items/{id}", response_class=HTMLResponse)
async def read_item(request: Request, id: str):
    return templates.TemplateResponse("item.html", {"request": request, "id": id})
```

I wanted to preserve this approach as much as possible, but allow the possibility to `render_block`--thus sending only the applicable block content.

My approach was to use a decorator to define the `block_name`. Everything else stays pretty much the same from the FastAPI perspective.

The end result/usage ends up looking kind of like this:

```py
app = FastAPI()

templates = Jinja2Templates(directory="templates")

@app.get("/items/{id}", response_class=HTMLResponse)
@render_block(templates, block_name="content")
async def read_item(request: Request, id: str):
    return templates.TemplateResponse("item.html", {"request": request, "id": id})
```

The result is the same as `render_block` in the other applications (Flask/Quart).

the `render_block` decorator takes the `Jinja2Templates` object as the first (positional) parameter. This is needed in order to extract the Jinja `Environment` object. The `template_name`, as well as the necessary `request` k,v pair, are both extracted from the FastAPI `TemplateResponse` method (from within the decorator). Then, the response is rebuilt with the `jinja2_fragments.render_block` method.

> Note: The decorator also takes additional key/value pairs and inserts those into the context as needed. Also, if the `block_name` is excluded from the decorator, the `TemplateResponse` will be rendered normally.

Last thing:
This is my first contribution to a library, so I apologize if anything is a little clunky. I've yet to add tests on my end, but I was able to confirm that it was working as expected on one of my own apps. 