### PR TITLE
Add missing test dependency (httpx)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ tests_requires = [
     "flask >= 2.1.0",
     "quart >= 0.18.0",
     "fastapi",
+    "starlette[full]",
     "pytest",
     "pytest_asyncio",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ import fastapi
 import flask
 import pytest
 import quart
-from fastapi.testclient import TestClient
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+from starlette.testclient import TestClient
 
 from jinja2_fragments.fastapi import Jinja2Blocks
 from jinja2_fragments.flask import render_block as flask_render_block


### PR DESCRIPTION
Following the testing instructions to run the tests from a clean environment fail at the last step due to a missing httpx dependency.

To reproduce:
```bash
$ python3 -m venv .venv
$ . .venv/bin/activate
$ pip install -e .[tests]
$ pytest

ImportError while loading conftest 'jinja2-fragments/tests/conftest.py'.
tests/conftest.py:7: in <module>
    from fastapi.testclient import TestClient
.venv/lib/python3.10/site-packages/fastapi/testclient.py:1: in <module>
    from starlette.testclient import TestClient as TestClient  # noqa
.venv/lib/python3.10/site-packages/starlette/testclient.py:16: in <module>
    import httpx
E   ModuleNotFoundError: No module named 'httpx'
```

Considering that FastAPI's test client [directly reuses Starlette's](https://github.com/tiangolo/fastapi/blob/master/fastapi/testclient.py), it's best to add [Starlette's test dependencies](https://github.com/encode/starlette/blob/master/pyproject.toml#L41) than FastAPI's (that has a very long list).

:snake: :man_juggling: 