### PR TITLE
Fix Flask/Quart signal name typo and add tests for Flask signals

### DIFF
--- a/src/jinja2_fragments/flask.py
+++ b/src/jinja2_fragments/flask.py
@@ -19,7 +19,7 @@ jinja2_fragments_signals = Namespace()
 before_render_template_block = jinja2_fragments_signals.signal(
     "before-render-template-block"
 )
-template_block_rendered = jinja2_fragments_signals.signal("template-bock-rendered")
+template_block_rendered = jinja2_fragments_signals.signal("template-block-rendered")
 
 
 def render_block(template_name: str, block_name: str, **context: typing.Any) -> str:

--- a/src/jinja2_fragments/quart.py
+++ b/src/jinja2_fragments/quart.py
@@ -15,7 +15,7 @@ jinja2_fragments_signals = AsyncNamespace()
 before_render_template_block = jinja2_fragments_signals.signal(
     "before-render-template-block"
 )
-template_block_rendered = jinja2_fragments_signals.signal("template-bock-rendered")
+template_block_rendered = jinja2_fragments_signals.signal("template-block-rendered")
 
 
 async def render_block(

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,7 +1,11 @@
 import pytest
 
 from jinja2_fragments import BlockNotFoundError
-from jinja2_fragments.flask import render_block
+from jinja2_fragments.flask import (
+    before_render_template_block,
+    render_block,
+    template_block_rendered,
+)
 
 
 class TestFlaskRenderBlock:
@@ -39,3 +43,44 @@ class TestFlaskRenderBlock:
                 render_block("simple_page.html.jinja2", "invalid_block")
             assert "invalid_block" in exc.value
             assert "simple_page.html.jinja2" in exc.value
+
+    @pytest.mark.parametrize(
+        "signal",
+        [
+            before_render_template_block,
+            template_block_rendered,
+        ],
+    )
+    def test_signals(app, flask_app, flask_client, signal):
+        recorded = []
+
+        def record(sender, template_name, block_name, context):
+            context["testing"] = "yes please"
+            recorded.append((sender, template_name, block_name, context))
+
+        def call():
+            flask_client.get("/simple_page", query_string={"only_content": "true"})
+
+        # Test for absence of typo in signal name
+        assert signal is globals().get(signal.name.replace("-", "_"))
+
+        # No signal should be recorded
+        call()
+        assert len(recorded) == 0
+
+        # Connect, record one signal
+        signal.connect(record, flask_app)
+        call()
+        assert len(recorded) == 1
+
+        # Disconnect, stop recording signals
+        signal.disconnect(record, flask_app)
+        call()
+        assert len(recorded) == 1
+
+        # Verify values sent in the signal
+        sender, template_name, block_name, context = recorded[0]
+        assert sender == flask_app
+        assert template_name == "simple_page.html.jinja2"
+        assert block_name == "content"
+        assert context["testing"] == "yes please"


### PR DESCRIPTION
This PR fixes a typo in a signal name for the Flask and Quart modules and adds some missing tests.

Considering this project is not yet at version 1.0 and [no public repository on GitHub](https://github.com/search?q=%22template_block_rendered%22%7C%22template-bock-rendered%22&type=code) seems to be using these signals (from which only the name attribute has the typo), it is likely overkill to emit two signals (with and without typo) and go through a deprecation release cycle to remove the bad one.

For Flask, doing so properly would require subclassing blinker.Namespace (or Flask's fake Namespace [which is going to be deprecated](https://github.com/pallets/flask/commit/9cb1a7a52d7927071e2b737d52f902f006969e82) in Flask's next version) to override the signal method, check for the name with a typo and emit a deprecation warning before returning the signal associated to the value without a typo.

I am not adding equivalent tests for Quart at this point mainly because I am less familiar with it, but here are a few leads that may be useful going forward. Quart currently has a custom implementation of signals due to its async nature. This is going to change with its next release to be more uniform with Flask (as a newer blinker release deals with it upstream). This will break the `jinja2_fragments.quart` module, see [this diff](https://github.com/pallets/quart/commit/c9b555ff284bb54a45adab44c8e6d78ab8713da0#diff-06c6998a7df5c194dbff6fb170a923df59a9fefea198c21dd888957b8ecebfdc). A future new try/except statement to account for the backwards incompatible changes will complexify these tests.

## :snake: :man_juggling: 