### PR TITLE
Simplify BlockNotFoundError with dataclass and test it properly

### DIFF
--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from jinja2 import Environment
 
 
-@dataclass
+@dataclass(eq=False)
 class BlockNotFoundError(Exception):
     block_name: str
     template_name: str

--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -1,16 +1,18 @@
 import typing
-from dataclasses import dataclass
 
 from jinja2 import Environment
 
 
-@dataclass(eq=False)
 class BlockNotFoundError(Exception):
-    block_name: str
-    template_name: str
-
-    def __str__(self):
-        return f"Block {self.block_name!r} not found on template {self.template_name!r}"
+    def __init__(
+        self, block_name: str, template_name: str, message: typing.Optional[str] = None
+    ):
+        self.block_name = block_name
+        self.template_name = template_name
+        super().__init__(
+            message
+            or f"Block {self.block_name!r} not found in template {self.template_name!r}"
+        )
 
 
 async def render_block_async(

--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -1,10 +1,16 @@
 import typing
+from dataclasses import dataclass
 
 from jinja2 import Environment
 
 
+@dataclass
 class BlockNotFoundError(Exception):
-    pass
+    block_name: str
+    template_name: str
+
+    def __str__(self):
+        return f"Block {self.block_name!r} not found on template {self.template_name!r}"
 
 
 async def render_block_async(
@@ -26,10 +32,8 @@ async def render_block_async(
     try:
         block_render_func = template.blocks[block_name]
     except KeyError:
-        raise BlockNotFoundError(
-            f"Block '{block_name}' not found on template '{template_name}'"
-        )
-    
+        raise BlockNotFoundError(block_name, template_name)
+
     ctx = template.new_context(dict(*args, **kwargs))
     try:
         return environment.concat(  # type: ignore
@@ -72,9 +76,7 @@ def render_block(
     try:
         block_render_func = template.blocks[block_name]
     except KeyError:
-        raise BlockNotFoundError(
-            f"Block '{block_name}' not found on template '{template_name}'"
-        )
+        raise BlockNotFoundError(block_name, template_name)
 
     ctx = template.new_context(dict(*args, **kwargs))
     try:

--- a/src/jinja2_fragments/flask.py
+++ b/src/jinja2_fragments/flask.py
@@ -7,7 +7,7 @@ except ModuleNotFoundError as e:
         "Install flask before using jinja2_fragments.flask"
     ) from e
 
-import jinja2_fragments
+from . import render_block as _render_block
 
 try:
     from blinker import Namespace
@@ -35,9 +35,7 @@ def render_block(template_name: str, block_name: str, **context: typing.Any) -> 
     before_render_template_block.send(
         app, template_name=template_name, block_name=block_name, context=context
     )
-    rendered = jinja2_fragments.render_block(
-        app.jinja_env, template_name, block_name, **context
-    )
+    rendered = _render_block(app.jinja_env, template_name, block_name, **context)
     template_block_rendered.send(
         app, template_name=template_name, block_name=block_name, context=context
     )

--- a/src/jinja2_fragments/quart.py
+++ b/src/jinja2_fragments/quart.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError as e:
 
 from quart.signals import AsyncNamespace
 
-import jinja2_fragments
+from . import render_block_async
 
 jinja2_fragments_signals = AsyncNamespace()
 before_render_template_block = jinja2_fragments_signals.signal(
@@ -33,7 +33,7 @@ async def render_block(
     await before_render_template_block.send(
         app, template_name=template_name, block_name=block_name, context=context
     )
-    rendered = await jinja2_fragments.render_block_async(
+    rendered = await render_block_async(
         app.jinja_env, template_name, block_name, **context
     )
     await template_block_rendered.send(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,11 +55,7 @@ def get_template(environment):
 @pytest.fixture(scope="session")
 def flask_app():
     app = flask.Flask(__name__)
-    app.config.update(
-        {
-            "TESTING": True,
-        }
-    )
+    app.config["TESTING"] = True
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.trim_blocks = True
 
@@ -102,11 +98,7 @@ def flask_client(flask_app):
 @pytest.fixture(scope="session")
 def quart_app():
     app = quart.Quart(__name__)
-    app.config.from_mapping(
-        {
-            "TESTING": True,
-        }
-    )
+    app.config["TESTING"] = True
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.trim_blocks = True
 
@@ -209,6 +201,13 @@ def fastapi_app():
             page_to_render,
             {"request": request, "lucky_number": LUCKY_NUMBER},
             block_name="inner",
+        )
+
+    @_app.get("/invalid_block")
+    async def invalid_block(request: fastapi.requests.Request):
+        """Decorator wraps around route method and includes an unexisting block name."""
+        return templates.TemplateResponse(
+            "simple_page.html.jinja2", {"request": request}, block_name="invalid_block"
         )
 
     return _app

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,5 +1,9 @@
 import re
 
+import pytest
+
+from jinja2_fragments import BlockNotFoundError
+
 
 class TestFastAPIRenderBlock:
     """Tests each of the methods to make sure the html generated is
@@ -48,3 +52,10 @@ class TestFastAPIRenderBlock:
         html = get_html("nested_blocks_and_variables_inner.html")
         html = re.sub(r"[\s\"]*", "", html)
         assert html == response_text
+
+    def test_exception(self, fastapi_client):
+        with pytest.raises(BlockNotFoundError) as exc:
+            fastapi_client.get("/invalid_block")
+
+        assert exc.value.block_name == "invalid_block"
+        assert exc.value.template_name == "simple_page.html.jinja2"

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -41,8 +41,9 @@ class TestFlaskRenderBlock:
         with pytest.raises(BlockNotFoundError) as exc:
             with flask_app.app_context():
                 render_block("simple_page.html.jinja2", "invalid_block")
-            assert "invalid_block" in exc.value
-            assert "simple_page.html.jinja2" in exc.value
+
+        assert exc.value.block_name == "invalid_block"
+        assert exc.value.template_name == "simple_page.html.jinja2"
 
     @pytest.mark.parametrize(
         "signal",

--- a/tests/test_quart.py
+++ b/tests/test_quart.py
@@ -42,5 +42,6 @@ class TestQuartRenderBlock:
         with pytest.raises(BlockNotFoundError) as exc:
             async with quart_app.app_context():
                 await render_block("simple_page.html.jinja2", "invalid_block")
-            assert "invalid_block" in exc.value
-            assert "simple_page.html.jinja2" in exc.value
+
+        assert exc.value.block_name == "invalid_block"
+        assert exc.value.template_name == "simple_page.html.jinja2"

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -34,19 +34,19 @@ class TestFullpage:
 
 
 class TestBlockNotFoundError:
-    def test_dataclass_exception(self):
+    def test_exception_message(self):
         """
-        This tests the use of dataclasses with for the BlockNotFoundError exception.
-        To conform with non-dataclasses exceptions, instances should be mutable,
-        hashable and not equal to other instances of the class.
+        This tests the optional message kwarg in the BlockNotFoundError exception.
         """
 
-        a = BlockNotFoundError("block", "template")
-        b = BlockNotFoundError("block", "template")
-        assert a != b
-        assert a is not b
-        hash(a)
-        a.hello = "world"
+        block, template = "the_block", "the_template"
+        message = f"{block} not found in {template}, please verify the values"
+
+        a = BlockNotFoundError(block, template)
+        assert "please" not in str(a)
+
+        b = BlockNotFoundError(block, template, message)
+        assert str(b) == message
 
 
 class TestRenderBlock:

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -88,8 +88,9 @@ class TestRenderBlock:
             render_block(
                 environment, template_name, block, params
             ) if params else render_block(environment, template_name, block)
-            assert block in exc.value
-            assert template_name in exc.value
+
+        assert exc.value.block_name == block
+        assert exc.value.template_name == template_name
 
 
 class TestAsyncRenderBlock:

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -33,6 +33,22 @@ class TestFullpage:
         assert html == rendered
 
 
+class TestBlockNotFoundError:
+    def test_dataclass_exception(self):
+        """
+        This tests the use of dataclasses with for the BlockNotFoundError exception.
+        To conform with non-dataclasses exceptions, instances should be mutable,
+        hashable and not equal to other instances of the class.
+        """
+
+        a = BlockNotFoundError("block", "template")
+        b = BlockNotFoundError("block", "template")
+        assert a != b
+        assert a is not b
+        hash(a)
+        a.hello = "world"
+
+
 class TestRenderBlock:
     @pytest.mark.parametrize(
         "template_name, html_name, block, params",


### PR DESCRIPTION
The tests for BlockNotFoundError were all broken. The assert statements were not executed because they were inside the pytest.raises context and after the exception was raised. When de-indenting assert statements so that they are executed properly, an exception is raised: `TypeError: argument of type 'BlockNotFoundError' is not iterable`. The test should have checked `block in str(exc.value)`.

I decided to make this exception easier to raise and test with exact matches while reducing code duplication by leveraging dataclasses. :slightly_smiling_face: These were [introduced in Python 3.7](https://docs.python.org/3.7/library/dataclasses.html), and everyone using jinja2_fragments will be using at least this version, as it depends on `jinja2 >= 3.1.0` which [requires Python >= 3.7](https://github.com/pallets/jinja/blob/3.1.0/setup.cfg#L36), so there is no risk of breaking anyone's environment.

I also tweaked the import statements in the flask and quart modules to be more consistent with fastapi.

Finally, I added a missing test for BlockNotFoundError for `fastapi.Jinja2Blocks`.

## :snake: :man_juggling: 