### PR TITLE
Fix Sanic tests for Python 3.7

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import flask
 import pytest
 import quart
 
-if sys.version_info > (3, 7):
+if sys.version_info >= (3, 8):
     import sanic
     import sanic_ext
 from jinja2 import Environment, FileSystemLoader, select_autoescape

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 import pathlib
+import sys
 
 import fastapi
 import flask
 import pytest
 import quart
-import sanic
-import sanic_ext
+
+if sys.version_info > (3, 7):
+    import sanic
+    import sanic_ext
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from starlette.testclient import TestClient
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,9 @@ from jinja2_fragments.fastapi import Jinja2Blocks
 from jinja2_fragments.flask import render_block as flask_render_block
 from jinja2_fragments.quart import render_block as quart_render_block
 
-if sys.version_info >= (3, 8):
+SANIC_ENABLED = sys.version_info >= (3, 8)
+
+if SANIC_ENABLED:
     import sanic
     import sanic_ext
 
@@ -228,6 +230,9 @@ def fastapi_client(fastapi_app):
 
 @pytest.fixture(scope="session")
 def sanic_app():
+    if not SANIC_ENABLED:
+        return
+
     app = sanic.Sanic(__name__)
     app.extend(config=sanic_ext.Config(templating_path_to_templates="tests/templates"))
     app.ext.environment.lstrip_blocks = True
@@ -262,4 +267,7 @@ def sanic_app():
 
 @pytest.fixture(scope="session")
 def sanic_client(sanic_app: sanic.Sanic):
+    if not SANIC_ENABLED:
+        return
+
     return sanic_app.test_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,17 +5,18 @@ import fastapi
 import flask
 import pytest
 import quart
-
-if sys.version_info >= (3, 8):
-    import sanic
-    import sanic_ext
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from starlette.testclient import TestClient
 
 from jinja2_fragments.fastapi import Jinja2Blocks
 from jinja2_fragments.flask import render_block as flask_render_block
 from jinja2_fragments.quart import render_block as quart_render_block
-from jinja2_fragments.sanic import render as sanic_render
+
+if sys.version_info >= (3, 8):
+    import sanic
+    import sanic_ext
+
+    from jinja2_fragments.sanic import render as sanic_render
 
 NAME = "Guido"
 LUCKY_NUMBER = "42"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,7 +266,7 @@ def sanic_app():
 
 
 @pytest.fixture(scope="session")
-def sanic_client(sanic_app: sanic.Sanic):
+def sanic_client(sanic_app: "sanic.Sanic"):
     if not SANIC_ENABLED:
         return
 

--- a/tests/test_sanic.py
+++ b/tests/test_sanic.py
@@ -15,7 +15,7 @@ class TestSanicRenderBlock:
         ],
     )
     def test_simple_page(
-        self, sanic_client: SanicTestClient, get_html, only_content, html_name
+        self, sanic_client: "SanicTestClient", get_html, only_content, html_name
     ):
         _, response = sanic_client.get(
             "/simple_page", params={"only_content": only_content}

--- a/tests/test_sanic.py
+++ b/tests/test_sanic.py
@@ -6,7 +6,9 @@ if sys.version_info > (3, 7):
     from sanic_testing.testing import SanicTestClient
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 7))
+@pytest.mark.skipif(
+    sys.version_info <= (3, 7), reason="Sanic requires python3.8 or higher"
+)
 class TestSanicRenderBlock:
     @pytest.mark.parametrize(
         "only_content, html_name",

--- a/tests/test_sanic.py
+++ b/tests/test_sanic.py
@@ -1,14 +1,11 @@
-import sys
-
 import pytest
+from conftest import SANIC_ENABLED
 
-if sys.version_info >= (3, 8):
+if SANIC_ENABLED:
     from sanic_testing.testing import SanicTestClient
 
 
-@pytest.mark.skipif(
-    not (sys.version_info >= (3, 8)), reason="Sanic requires python 3.8 or higher"
-)
+@pytest.mark.skipif(not SANIC_ENABLED, reason="Sanic requires python 3.8 or higher")
 class TestSanicRenderBlock:
     @pytest.mark.parametrize(
         "only_content, html_name",

--- a/tests/test_sanic.py
+++ b/tests/test_sanic.py
@@ -2,12 +2,12 @@ import sys
 
 import pytest
 
-if sys.version_info > (3, 7):
+if sys.version_info >= (3, 8):
     from sanic_testing.testing import SanicTestClient
 
 
 @pytest.mark.skipif(
-    sys.version_info <= (3, 7), reason="Sanic requires python3.8 or higher"
+    not (sys.version_info >= (3, 8)), reason="Sanic requires python 3.8 or higher"
 )
 class TestSanicRenderBlock:
     @pytest.mark.parametrize(

--- a/tests/test_sanic.py
+++ b/tests/test_sanic.py
@@ -1,7 +1,12 @@
+import sys
+
 import pytest
-from sanic_testing.testing import SanicTestClient
+
+if sys.version_info > (3, 7):
+    from sanic_testing.testing import SanicTestClient
 
 
+@pytest.mark.skipif(sys.version_info <= (3, 7))
 class TestSanicRenderBlock:
     @pytest.mark.parametrize(
         "only_content, html_name",


### PR DESCRIPTION
Sanic does not support Python 3.7, so we need to add some code to skip these tests and fixtures on Python 3.7.