### PR TITLE
feat: returning HTMLResponse for rendered block in FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ Assuming the same template as the examples above:
 ```py
 from fastapi import FastAPI
 from fastapi.requests import Request
-from fastapi.responses import HTMLResponse
 from jinja2_fragments.fastapi import Jinja2Blocks
 
 app = FastAPI()
@@ -128,7 +127,7 @@ async def full_page(request: Request):
         {"request": request, "magic_number": 42}
     )
 
-@app.get("/only_content", response_class=HTMLResponse)
+@app.get("/only_content")
 async def only_content(request: Request):
     return templates.TemplateResponse(
         "page.html.jinja2",

--- a/src/jinja2_fragments/fastapi.py
+++ b/src/jinja2_fragments/fastapi.py
@@ -2,6 +2,7 @@ import typing
 
 try:
     from starlette.background import BackgroundTask
+    from starlette.responses import HTMLResponse
     from starlette.templating import Jinja2Templates, _TemplateResponse
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
@@ -29,17 +30,24 @@ class Jinja2Blocks(Jinja2Templates):
         background: typing.Optional[BackgroundTask] = None,
         *,
         block_name: typing.Optional[str] = None,
-    ) -> _TemplateResponse:
+    ) -> typing.Union[_TemplateResponse, HTMLResponse]:
         if "request" not in context:
             raise ValueError('context must include a "request" key')
         template = self.get_template(name)
 
         if block_name:
-            template = render_block(
+            content = render_block(
                 self.env,
                 name,
                 block_name,
                 context,
+            )
+            return HTMLResponse(
+                content=content,
+                status_code=status_code,
+                headers=headers,
+                media_type=media_type,
+                background=background,
             )
         return _TemplateResponse(
             template,

--- a/src/jinja2_fragments/fastapi.py
+++ b/src/jinja2_fragments/fastapi.py
@@ -29,13 +29,13 @@ class Jinja2Blocks(Jinja2Templates):
         background: typing.Optional[BackgroundTask] = None,
         *,
         block_name: typing.Optional[str] = None,
-    ) -> typing.Union[_TemplateResponse, str]:
+    ) -> _TemplateResponse:
         if "request" not in context:
             raise ValueError('context must include a "request" key')
         template = self.get_template(name)
 
         if block_name:
-            return render_block(
+            template = render_block(
                 self.env,
                 name,
                 block_name,

--- a/src/jinja2_fragments/fastapi.py
+++ b/src/jinja2_fragments/fastapi.py
@@ -2,7 +2,7 @@ import typing
 
 try:
     from starlette.background import BackgroundTask
-    from starlette.responses import HTMLResponse
+    from starlette.responses import HTMLResponse, Response
     from starlette.templating import Jinja2Templates, _TemplateResponse
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
@@ -30,7 +30,7 @@ class Jinja2Blocks(Jinja2Templates):
         background: typing.Optional[BackgroundTask] = None,
         *,
         block_name: typing.Optional[str] = None,
-    ) -> typing.Union[_TemplateResponse, HTMLResponse]:
+    ) -> Response:
         if "request" not in context:
             raise ValueError('context must include a "request" key')
         template = self.get_template(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import flask
 import pytest
 import quart
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+from starlette.responses import HTMLResponse
 from starlette.testclient import TestClient
 
 from jinja2_fragments.fastapi import Jinja2Blocks
@@ -202,6 +203,20 @@ def fastapi_app():
     @_app.get("/nested_inner")
     async def nested_inner(request: fastapi.requests.Request):
         """Decorator wraps around route method and includes `block_name`
+        plus parameters `name` and `lucky_number` which are passed
+        to the template. As a result, `inner` will be rendered.
+        """
+        page_to_render = "nested_blocks_and_variables.html.jinja2"
+        return templates.TemplateResponse(
+            page_to_render,
+            {"request": request, "lucky_number": LUCKY_NUMBER},
+            block_name="inner",
+        )
+
+    @_app.get("/nested_inner_html_response_class", response_class=HTMLResponse)
+    async def nested_inner_html_response_class(request: fastapi.requests.Request):
+        """Decorator wraps around route method with
+        `response_class=HTMLResponse` and includes `block_name`
         plus parameters `name` and `lucky_number` which are passed
         to the template. As a result, `inner` will be rendered.
         """

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -53,6 +53,18 @@ class TestFastAPIRenderBlock:
         html = re.sub(r"[\s\"]*", "", html)
         assert html == response_text
 
+    def test_nested_inner_html_response_class(
+        self,
+        fastapi_client,
+        get_html,
+    ):
+        """using `response_class=HTMLResponse` should still work"""
+        response = fastapi_client.get("/nested_inner_html_response_class")
+        response_text = re.sub(r"[\s\"]*", "", response.text).replace("\\n", "")
+        html = get_html("nested_blocks_and_variables_inner.html")
+        html = re.sub(r"[\s\"]*", "", html)
+        assert html == response_text
+
     def test_exception(self, fastapi_client):
         with pytest.raises(BlockNotFoundError) as exc:
             fastapi_client.get("/invalid_block")

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -27,7 +27,7 @@ class TestFastAPIRenderBlock:
         get_html,
     ):
         response = fastapi_client.get("/simple_page_content")
-        response_text = response.text.replace('"', "").strip("\\n")
+        response_text = response.text.replace('"', "").strip("\n")
         html = get_html("simple_page_content.html").strip("\n")
         assert html == response_text
 


### PR DESCRIPTION
I think its a bit more intutive if the rendered block also returns somekind of response. Currently calling `templates.TemplateResponse()`does not return a `Response` if we only want to have one block rendered. Instead it returns a string. This would be especially useful if you want to conditionally render a block or the full content in the same route. Currently the args `status_code`,`headers`, `media_type` and `background` are unused when only rendering a fragment which could lead to confusion. Whats your opinion? If you like the PR we shouldn't forget to update the readme :)