### PR TITLE
Fix quart signals upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requires = [
 ]
 
 tests_requires = [
-    "quart >= 0.18.0, < 0.19.0",
+    "quart >= 0.18.0",
     "flask >= 2.1.0",
     "fastapi",
     "sanic",

--- a/src/jinja2_fragments/quart.py
+++ b/src/jinja2_fragments/quart.py
@@ -11,7 +11,7 @@ try:
     # Quart >= 0.19.0
     from quart.signals import Namespace
 
-    CUSTOM_SIGNALj = False
+    CUSTOM_SIGNAL = False
 except ImportError:
     # Quart < 0.19.0
     from quart.signals import AsyncNamespace as Namespace

--- a/tests/test_quart.py
+++ b/tests/test_quart.py
@@ -14,8 +14,10 @@ class TestQuartRenderBlock:
             (True, "simple_page_content.html"),
         ],
     )
-    @pytest.mark.asynci
-    @pytest.mark.skipif(sys.version_info <= (3, 7))
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8), reason="Quart requires Python 3.8.0 or higher"
+    )
     async def test_simple_page(self, quart_client, get_html, only_content, html_name):
         response = await quart_client.get(
             "/simple_page", query_string={"only_content": only_content}
@@ -33,7 +35,9 @@ class TestQuartRenderBlock:
         ],
     )
     @pytest.mark.asyncio
-    @pytest.mark.skipif(sys.version_info <= (3, 7))
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8), reason="Quart requires Python 3.8.0 or higher"
+    )
     async def test_nested_page(self, quart_client, get_html, route, html_name):
         response = await quart_client.get(route)
         response_text = await response.get_data(True)

--- a/tests/test_quart.py
+++ b/tests/test_quart.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from jinja2_fragments import BlockNotFoundError
@@ -12,7 +14,8 @@ class TestQuartRenderBlock:
             (True, "simple_page_content.html"),
         ],
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asynci
+    @pytest.mark.skipif(sys.version_info <= (3, 7))
     async def test_simple_page(self, quart_client, get_html, only_content, html_name):
         response = await quart_client.get(
             "/simple_page", query_string={"only_content": only_content}
@@ -30,6 +33,7 @@ class TestQuartRenderBlock:
         ],
     )
     @pytest.mark.asyncio
+    @pytest.mark.skipif(sys.version_info <= (3, 7))
     async def test_nested_page(self, quart_client, get_html, route, html_name):
         response = await quart_client.get(route)
         response_text = await response.get_data(True)

--- a/tests/test_quart.py
+++ b/tests/test_quart.py
@@ -46,6 +46,9 @@ class TestQuartRenderBlock:
         assert html == response_text
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8), reason="Quart requires Python 3.8.0 or higher"
+    )
     async def test_exception(self, quart_app):
         with pytest.raises(BlockNotFoundError) as exc:
             async with quart_app.app_context():


### PR DESCRIPTION
Quart changed how it is initializing signals, removing the `AsyncNamespace` class jinja2-fragments was relying on. Hence, the jinja2-fragments was not compatible with Quart>=0.19.0, which is when this change became effective.

This commit adds support for both Quart<=19.0.0 and Quart>=19.0.0.

It also changes the Quart tests to not run on Python<3.8, as Quart requires 3.8 or higher.

Ref: https://github.com/sponsfreixes/jinja2-fragments/issues/19