### PR TITLE
inject macros into context of block being rendered

### DIFF
--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -37,7 +37,7 @@ async def render_block_async(
     except KeyError:
         raise BlockNotFoundError(block_name, template_name)
 
-    template_module = template.module
+    template_module = await template.make_module_async()
     macros = {
         m: getattr(template_module, m)
         for m in dir(template_module)

--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -38,7 +38,11 @@ async def render_block_async(
         raise BlockNotFoundError(block_name, template_name)
 
     template_module = template.module
-    macros = {m: getattr(template_module, m) for m in dir(template_module) if isinstance(getattr(template_module, m), Macro)}
+    macros = {
+        m: getattr(template_module, m)
+        for m in dir(template_module)
+        if isinstance(getattr(template_module, m), Macro)
+    }
     ctx = template.new_context(vars=dict(*args, **kwargs), locals=macros)
     try:
         return environment.concat(  # type: ignore
@@ -84,7 +88,11 @@ def render_block(
         raise BlockNotFoundError(block_name, template_name)
 
     template_module = template.module
-    macros = {m: getattr(template_module, m) for m in dir(template_module) if isinstance(getattr(template_module, m), Macro)}
+    macros = {
+        m: getattr(template_module, m)
+        for m in dir(template_module)
+        if isinstance(getattr(template_module, m), Macro)
+    }
     ctx = template.new_context(vars=dict(*args, **kwargs), locals=macros)
     try:
         return environment.concat(block_render_func(ctx))  # type: ignore

--- a/tests/rendered_templates/block_with_macros_content.html
+++ b/tests/rendered_templates/block_with_macros_content.html
@@ -1,0 +1,6 @@
+    <fieldset>
+        <legend>The Legend</legend>
+                <p>This is the content. Hello Guido!</p>
+        <p>This is the bottom paragraph. Lucky number: 42</p>
+
+    </fieldset>

--- a/tests/templates/block_with_macros.html.jinja2
+++ b/tests/templates/block_with_macros.html.jinja2
@@ -1,0 +1,22 @@
+{% macro render_fieldset(legend) %}
+    <fieldset>
+        <legend>{{ legend }}</legend>
+        {{ caller() }}
+    </fieldset>
+{% endmacro %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title }}</title>
+</head>
+<body>
+    <h1>This is a header</h1>
+    {% block content %}
+        {% call render_fieldset(legend) %}
+        <p>This is the content. Hello {{ name }}!</p>
+        <p>This is the bottom paragraph. Lucky number: {{ lucky_number }}</p>
+        {% endcall  %}
+    {% endblock %}
+</body>
+</html>

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -66,6 +66,17 @@ class TestRenderBlock:
                 "inner",
                 {"lucky_number": LUCKY_NUMBER},
             ),
+            (
+                "block_with_macros.html.jinja2",
+                "block_with_macros_content.html",
+                "content",
+                {
+                    "title": "This is a title",
+                    "name": NAME,
+                    "lucky_number": LUCKY_NUMBER,
+                    "legend": "The Legend",
+                },
+            ),
         ],
     )
     def test_block_render(
@@ -126,6 +137,17 @@ class TestAsyncRenderBlock:
                 "nested_blocks_and_variables_inner.html",
                 "inner",
                 {"lucky_number": LUCKY_NUMBER},
+            ),
+            (
+                "block_with_macros.html.jinja2",
+                "block_with_macros_content.html",
+                "content",
+                {
+                    "title": "This is a title",
+                    "name": NAME,
+                    "lucky_number": LUCKY_NUMBER,
+                    "legend": "The Legend",
+                },
             ),
         ],
     )


### PR DESCRIPTION
Related to #21 : This modification worked for my case to load the macros into the context of the fragment being rendered.