### PR TITLE
Fix dictionary access

### DIFF
--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -37,7 +37,7 @@ async def render_block_async(
     except KeyError:
         raise BlockNotFoundError(block_name, template_name)
 
-    template_module = await template.make_module_async()
+    template_module = await template.make_module_async(vars=dict(*args, **kwargs))
     macros = {
         m: getattr(template_module, m)
         for m in dir(template_module)
@@ -87,7 +87,7 @@ def render_block(
     except KeyError:
         raise BlockNotFoundError(block_name, template_name)
 
-    template_module = template.module
+    template_module = template.make_module(vars=dict(*args, **kwargs))
     macros = {
         m: getattr(template_module, m)
         for m in dir(template_module)

--- a/tests/rendered_templates/block_with_dictionary_content.html
+++ b/tests/rendered_templates/block_with_dictionary_content.html
@@ -1,0 +1,2 @@
+            name = Guido
+            lucky_number = 42

--- a/tests/templates/block_with_dictionary.html.jinja2
+++ b/tests/templates/block_with_dictionary.html.jinja2
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title }}</title>
+</head>
+<body>
+    <h1>This is a header</h1>
+    {% block content %}
+        {% for key, val in test_dict.items() %}
+            {{ key }} = {{ val }}
+        {% endfor  %}
+    {% endblock %}
+</body>
+</html>

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -165,7 +165,6 @@ class TestAsyncRenderBlock:
                 "block_with_dictionary_content.html",
                 "content",
                 {
-                    "title": "This is a title",
                     "test_dict": {
                         "name": NAME,
                         "lucky_number": LUCKY_NUMBER,

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -77,6 +77,17 @@ class TestRenderBlock:
                     "legend": "The Legend",
                 },
             ),
+            (
+                "block_with_dictionary.html.jinja2",
+                "block_with_dictionary_content.html",
+                "content",
+                {
+                    "test_dict": {
+                        "name": NAME,
+                        "lucky_number": LUCKY_NUMBER,
+                    },
+                },
+            ),
         ],
     )
     def test_block_render(
@@ -147,6 +158,18 @@ class TestAsyncRenderBlock:
                     "name": NAME,
                     "lucky_number": LUCKY_NUMBER,
                     "legend": "The Legend",
+                },
+            ),
+            (
+                "block_with_dictionary.html.jinja2",
+                "block_with_dictionary_content.html",
+                "content",
+                {
+                    "title": "This is a title",
+                    "test_dict": {
+                        "name": NAME,
+                        "lucky_number": LUCKY_NUMBER,
+                    },
                 },
             ),
         ],


### PR DESCRIPTION
Fixes #32 

The PR #30 created a regression of accessing dictionary .items() (and likely any object.attribute)

This fix passes the variables when building the module.