### PR TITLE
Support rendering multiple blocks

### DIFF
--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -85,3 +85,57 @@ def render_block(
         return environment.concat(block_render_func(ctx))  # type: ignore
     except Exception:
         environment.handle_exception()
+
+
+def render_block_list(
+    environment: Environment,
+    template_name: str,
+    block_name_list: list[str],
+    *args: typing.Any,
+    **kwargs: typing.Any,
+) -> str:
+    """This returns one or more rendered template blocks as a string."""
+    if environment.is_async:
+        import asyncio
+
+        close = False
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            close = True
+
+        try:
+            raise NotImplementedError()
+        finally:
+            if close:
+                loop.close()
+
+    return _render_template_blocks(
+        environment, template_name, block_name_list, *args, **kwargs
+    )
+
+
+def _render_template_blocks(
+    environment: Environment,
+    template_name: str,
+    block_name_list: list[str],
+    *args: typing.Any,
+    **kwargs: typing.Any,
+) -> str:
+    contents: list[str] = []
+    template = environment.get_template(template_name)
+
+    for block_name in block_name_list:
+        try:
+            block_render_func = template.blocks[block_name]
+        except KeyError:
+            raise BlockNotFoundError(block_name, template_name)
+
+        ctx = template.new_context(dict(*args, **kwargs))
+        try:
+            contents.append(environment.concat(block_render_func(ctx)))  # type: ignore
+        except Exception:
+            environment.handle_exception()
+    return "".join(contents)

--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -52,7 +52,7 @@ async def render_blocks_async(
     block_names: list[str],
     *args: typing.Any,
     **kwargs: typing.Any,
-):
+) -> str:
     """
     This works similar to :func:`render_blocks` but returns a coroutine that when
     awaited returns every rendered template block as a single string. This requires
@@ -61,7 +61,7 @@ async def render_blocks_async(
     if not environment.is_async:
         raise RuntimeError("The environment was not created with async mode enabled.")
 
-    return _render_template_blocks_async(
+    return await _render_template_blocks_async(
         environment, template_name, block_names, *args, **kwargs
     )
 

--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -87,10 +87,10 @@ def render_block(
         environment.handle_exception()
 
 
-def render_block_list(
+def render_blocks(
     environment: Environment,
     template_name: str,
-    block_name_list: list[str],
+    block_names: list[str],
     *args: typing.Any,
     **kwargs: typing.Any,
 ) -> str:
@@ -113,21 +113,21 @@ def render_block_list(
                 loop.close()
 
     return _render_template_blocks(
-        environment, template_name, block_name_list, *args, **kwargs
+        environment, template_name, block_names, *args, **kwargs
     )
 
 
 def _render_template_blocks(
     environment: Environment,
     template_name: str,
-    block_name_list: list[str],
+    block_names: list[str],
     *args: typing.Any,
     **kwargs: typing.Any,
 ) -> str:
     contents: list[str] = []
     template = environment.get_template(template_name)
 
-    for block_name in block_name_list:
+    for block_name in block_names:
         try:
             block_render_func = template.blocks[block_name]
         except KeyError:

--- a/src/jinja2_fragments/fastapi.py
+++ b/src/jinja2_fragments/fastapi.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError as e:
         "Install Starlette to use jinja2_fragments.fastapi"
     ) from e
 
-from . import render_block
+from . import render_block, render_block_list
 
 
 class InvalidContextError(Exception):
@@ -20,6 +20,21 @@ class Jinja2Blocks(Jinja2Templates):
     def __init__(self, directory, **env_options):
         super().__init__(directory, **env_options)
 
+    @typing.overload  # type: ignore
+    def TemplateResponse(
+        self,
+        name: str,
+        context: typing.Dict[str, typing.Any],
+        status_code: int = 200,
+        headers: typing.Optional[typing.Mapping[str, str]] = None,
+        media_type: typing.Optional[str] = None,
+        background: typing.Optional[BackgroundTask] = None,
+        *,
+        block_name_list: list[str] = [],
+    ) -> Response:
+        ...
+
+    @typing.overload
     def TemplateResponse(
         self,
         name: str,
@@ -31,9 +46,24 @@ class Jinja2Blocks(Jinja2Templates):
         *,
         block_name: typing.Optional[str] = None,
     ) -> Response:
+        ...
+
+    def TemplateResponse(
+        self,
+        name: str,
+        context: typing.Dict[str, typing.Any],
+        status_code: int = 200,
+        headers: typing.Optional[typing.Mapping[str, str]] = None,
+        media_type: typing.Optional[str] = None,
+        background: typing.Optional[BackgroundTask] = None,
+        **kwargs: typing.Any,
+    ) -> Response:
         if "request" not in context:
             raise ValueError('context must include a "request" key')
         template = self.get_template(name)
+
+        block_name = kwargs.get("block_name", None)
+        block_name_list = kwargs.get("block_name_list", [])
 
         if block_name:
             content = render_block(
@@ -49,6 +79,22 @@ class Jinja2Blocks(Jinja2Templates):
                 media_type=media_type,
                 background=background,
             )
+
+        if block_name_list:
+            content = render_block_list(
+                self.env,
+                name,
+                block_name_list,
+                context,
+            )
+            return HTMLResponse(
+                content=content,
+                status_code=status_code,
+                headers=headers,
+                media_type=media_type,
+                background=background,
+            )
+
         return _TemplateResponse(
             template,
             context,

--- a/src/jinja2_fragments/fastapi.py
+++ b/src/jinja2_fragments/fastapi.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError as e:
         "Install Starlette to use jinja2_fragments.fastapi"
     ) from e
 
-from . import render_block, render_block_list
+from . import render_block, render_blocks
 
 
 class InvalidContextError(Exception):
@@ -30,7 +30,7 @@ class Jinja2Blocks(Jinja2Templates):
         media_type: typing.Optional[str] = None,
         background: typing.Optional[BackgroundTask] = None,
         *,
-        block_name_list: list[str] = [],
+        block_names: list[str] = [],
     ) -> Response:
         ...
 
@@ -63,7 +63,7 @@ class Jinja2Blocks(Jinja2Templates):
         template = self.get_template(name)
 
         block_name = kwargs.get("block_name", None)
-        block_name_list = kwargs.get("block_name_list", [])
+        block_names = kwargs.get("block_names", [])
 
         if block_name:
             content = render_block(
@@ -80,11 +80,11 @@ class Jinja2Blocks(Jinja2Templates):
                 background=background,
             )
 
-        if block_name_list:
-            content = render_block_list(
+        if block_names:
+            content = render_blocks(
                 self.env,
                 name,
-                block_name_list,
+                block_names,
                 context,
             )
             return HTMLResponse(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,11 +223,35 @@ def fastapi_app():
             block_name="inner",
         )
 
+    @_app.get("/out_of_band_block")
+    async def out_of_band_block(
+        request: fastapi.requests.Request,
+    ):
+        """Decorator wraps around route method and includes `block_name_list`
+        parameter, so it will render content within all given blocks.
+        """
+        page_to_render = "oob_block_and_variables.html.jinja2"
+        return templates.TemplateResponse(
+            page_to_render,
+            {"request": request, "name": NAME, "lucky_number": LUCKY_NUMBER},
+            block_name_list=["content", "oob_content"],
+        )
+
     @_app.get("/invalid_block")
     async def invalid_block(request: fastapi.requests.Request):
         """Decorator wraps around route method and includes an unexisting block name."""
         return templates.TemplateResponse(
             "simple_page.html.jinja2", {"request": request}, block_name="invalid_block"
+        )
+
+    @_app.get("/invalid_block_list")
+    async def invalid_block_list(request: fastapi.requests.Request):
+        """Decorator wraps around route method and includes an unexisting block name
+        passed as a list argument."""
+        return templates.TemplateResponse(
+            "simple_page.html.jinja2",
+            {"request": request},
+            block_name_list=["invalid_block"],
         )
 
     return _app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,14 +227,14 @@ def fastapi_app():
     async def out_of_band_block(
         request: fastapi.requests.Request,
     ):
-        """Decorator wraps around route method and includes `block_name_list`
+        """Decorator wraps around route method and includes `block_names`
         parameter, so it will render content within all given blocks.
         """
         page_to_render = "oob_block_and_variables.html.jinja2"
         return templates.TemplateResponse(
             page_to_render,
             {"request": request, "name": NAME, "lucky_number": LUCKY_NUMBER},
-            block_name_list=["content", "oob_content"],
+            block_names=["content", "oob_content"],
         )
 
     @_app.get("/invalid_block")
@@ -251,7 +251,7 @@ def fastapi_app():
         return templates.TemplateResponse(
             "simple_page.html.jinja2",
             {"request": request},
-            block_name_list=["invalid_block"],
+            block_names=["invalid_block"],
         )
 
     return _app

--- a/tests/rendered_templates/oob_block_and_variables_content.html
+++ b/tests/rendered_templates/oob_block_and_variables_content.html
@@ -1,0 +1,1 @@
+<p>This is the content. Hello Guido!</p>

--- a/tests/rendered_templates/oob_block_and_variables_content_and_oob.html
+++ b/tests/rendered_templates/oob_block_and_variables_content_and_oob.html
@@ -1,2 +1,2 @@
 <p>This is the content. Hello Guido!</p>
-<p>This is an out-of-bound update. Lucky number: 42</p>
+<p>This is an out-of-band update. Lucky number: 42</p>

--- a/tests/rendered_templates/oob_block_and_variables_content_and_oob.html
+++ b/tests/rendered_templates/oob_block_and_variables_content_and_oob.html
@@ -1,0 +1,2 @@
+<p>This is the content. Hello Guido!</p>
+<p>This is an out-of-bound update. Lucky number: 42</p>

--- a/tests/templates/oob_block_and_variables.html.jinja2
+++ b/tests/templates/oob_block_and_variables.html.jinja2
@@ -1,0 +1,8 @@
+{% extends "simple_page.html.jinja2" %}
+
+{% block content %}
+<p>This is the content. Hello {{ name }}!</p>
+{% endblock %}
+{% block oob_content %}
+<p>This is an out-of-bound update. Lucky number: {{ lucky_number }}</p>
+{% endblock %}

--- a/tests/templates/oob_block_and_variables.html.jinja2
+++ b/tests/templates/oob_block_and_variables.html.jinja2
@@ -4,5 +4,5 @@
 <p>This is the content. Hello {{ name }}!</p>
 {% endblock %}
 {% block oob_content %}
-<p>This is an out-of-bound update. Lucky number: {{ lucky_number }}</p>
+<p>This is an out-of-band update. Lucky number: {{ lucky_number }}</p>
 {% endblock %}

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -53,6 +53,17 @@ class TestFastAPIRenderBlock:
         html = re.sub(r"[\s\"]*", "", html)
         assert html == response_text
 
+    def test_out_of_band_update(
+        self,
+        fastapi_client,
+        get_html,
+    ):
+        response = fastapi_client.get("/out_of_band_block")
+        response_text = re.sub(r"[\s\"]*", "", response.text).replace("\\n", "")
+        html = get_html("oob_block_and_variables_content_and_oob.html")
+        html = re.sub(r"[\s\"]*", "", html)
+        assert html == response_text
+
     def test_nested_inner_html_response_class(
         self,
         fastapi_client,
@@ -68,6 +79,13 @@ class TestFastAPIRenderBlock:
     def test_exception(self, fastapi_client):
         with pytest.raises(BlockNotFoundError) as exc:
             fastapi_client.get("/invalid_block")
+
+        assert exc.value.block_name == "invalid_block"
+        assert exc.value.template_name == "simple_page.html.jinja2"
+
+    def test_exception_block_list(self, fastapi_client):
+        with pytest.raises(BlockNotFoundError) as exc:
+            fastapi_client.get("/invalid_block_list")
 
         assert exc.value.block_name == "invalid_block"
         assert exc.value.template_name == "simple_page.html.jinja2"

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -74,10 +74,10 @@ class TestRenderBlock:
             ),
         ],
     )
-    def test_block_render(
+    def test_render_block(
         self, environment, get_html, template_name, html_name, block, params
     ):
-        """Test that the block_render function works."""
+        """Test that the render_block function works."""
         rendered = (
             render_block(environment, template_name, block, params)
             if params
@@ -134,7 +134,7 @@ class TestRenderBlock:
         self, environment, get_html, template_name, html_name, block, params
     ):
         """
-        Test that the block_render function raises the right exception when passed an
+        Test that the render_block function raises the right exception when passed an
         invalid block name.
         """
         with pytest.raises(BlockNotFoundError) as exc:
@@ -166,7 +166,7 @@ class TestAsyncRenderBlock:
             ),
         ],
     )
-    async def test_async_block_render(
+    async def test_async_render_block(
         self,
         event_loop,
         async_environment,
@@ -176,7 +176,7 @@ class TestAsyncRenderBlock:
         block,
         params,
     ):
-        """Test that the block_render_async function works."""
+        """Test that the render_block_async function works."""
         rendered = (
             await render_block_async(async_environment, template_name, block, params)
             if params
@@ -184,7 +184,7 @@ class TestAsyncRenderBlock:
         )
 
         html = get_html(html_name)
-        assert html == rendered
+        assert html.strip() == rendered.strip()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -1,7 +1,12 @@
 import pytest
 from conftest import LUCKY_NUMBER, NAME
 
-from jinja2_fragments import BlockNotFoundError, render_block, render_block_async
+from jinja2_fragments import (
+    BlockNotFoundError,
+    render_block,
+    render_block_async,
+    render_block_list,
+)
 
 
 class TestFullpage:
@@ -80,6 +85,37 @@ class TestRenderBlock:
 
         html = get_html(html_name)
         assert html == rendered
+
+    @pytest.mark.parametrize(
+        "template_name, html_name, block_list, params",
+        [
+            ("simple_page.html.jinja2", "simple_page_content.html", ["content"], None),
+            (
+                "oob_block_and_variables.html.jinja2",
+                "oob_block_and_variables_content.html",
+                ["content"],
+                {"name": NAME},
+            ),
+            (
+                "oob_block_and_variables.html.jinja2",
+                "oob_block_and_variables_content_and_oob.html",
+                ["content", "oob_content"],
+                {"name": NAME, "lucky_number": LUCKY_NUMBER},
+            ),
+        ],
+    )
+    def test_block_list_render(
+        self, environment, get_html, template_name, html_name, block_list, params
+    ):
+        """Test that the block_list_render function works."""
+        rendered = (
+            render_block_list(environment, template_name, block_list, params)
+            if params
+            else render_block_list(environment, template_name, block_list)
+        )
+
+        html = get_html(html_name)
+        assert html.strip() == rendered.strip()
 
     @pytest.mark.parametrize(
         "template_name, html_name, block, params",

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -6,6 +6,7 @@ from jinja2_fragments import (
     render_block,
     render_block_async,
     render_blocks,
+    render_blocks_async,
 )
 
 
@@ -184,3 +185,42 @@ class TestAsyncRenderBlock:
 
         html = get_html(html_name)
         assert html == rendered
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "template_name, html_name, blocks, params",
+        [
+            ("simple_page.html.jinja2", "simple_page_content.html", ["content"], None),
+            (
+                "oob_block_and_variables.html.jinja2",
+                "oob_block_and_variables_content.html",
+                ["content"],
+                {"name": NAME},
+            ),
+            (
+                "oob_block_and_variables.html.jinja2",
+                "oob_block_and_variables_content_and_oob.html",
+                ["content", "oob_content"],
+                {"name": NAME, "lucky_number": LUCKY_NUMBER},
+            ),
+        ],
+    )
+    async def test_async_blocks_render(
+        self,
+        event_loop,
+        async_environment,
+        get_html,
+        template_name,
+        html_name,
+        blocks,
+        params,
+    ):
+        """Test that the render_blocks_async function works."""
+        rendered = (
+            await render_blocks_async(async_environment, template_name, blocks, params)
+            if params
+            else await render_blocks_async(async_environment, template_name, blocks)
+        )
+
+        html = get_html(html_name)
+        assert html.strip() == rendered.strip()

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -168,7 +168,6 @@ class TestAsyncRenderBlock:
     )
     async def test_async_render_block(
         self,
-        event_loop,
         async_environment,
         get_html,
         template_name,
@@ -207,7 +206,6 @@ class TestAsyncRenderBlock:
     )
     async def test_async_blocks_render(
         self,
-        event_loop,
         async_environment,
         get_html,
         template_name,

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -5,7 +5,7 @@ from jinja2_fragments import (
     BlockNotFoundError,
     render_block,
     render_block_async,
-    render_block_list,
+    render_blocks,
 )
 
 
@@ -87,7 +87,7 @@ class TestRenderBlock:
         assert html == rendered
 
     @pytest.mark.parametrize(
-        "template_name, html_name, block_list, params",
+        "template_name, html_name, blocks, params",
         [
             ("simple_page.html.jinja2", "simple_page_content.html", ["content"], None),
             (
@@ -104,14 +104,14 @@ class TestRenderBlock:
             ),
         ],
     )
-    def test_block_list_render(
-        self, environment, get_html, template_name, html_name, block_list, params
+    def test_render_blocks(
+        self, environment, get_html, template_name, html_name, blocks, params
     ):
-        """Test that the block_list_render function works."""
+        """Test that the render_blocks function works."""
         rendered = (
-            render_block_list(environment, template_name, block_list, params)
+            render_blocks(environment, template_name, blocks, params)
             if params
-            else render_block_list(environment, template_name, block_list)
+            else render_blocks(environment, template_name, blocks)
         )
 
         html = get_html(html_name)


### PR DESCRIPTION
Add support for rendering multiple blocks at once.

First of all I'm new to HTMX, if this should be accomplished in other ways you can just point me towards the right direction and close this.

I was following ThePrimeagen's introduction to HTMX on FrontEnd Masters but using Python + FastAPI instead of Golang + Echo and I noticed [this pattern](https://www.youtube.com/watch?v=x7v6SNIgJpE&t=4729s) he used for rendering the form PLUS an out-of-bound element to update the contacts.

```golang
c.Render(200, "form", newFormData())
return c.Render(200, "oob-contact", contact)
```

I tried searching how I could do that with my stack but found nothing, tried to do something similar by joining the resulting content but ended up with Content-Length header errors and I thought I could try to modify the library to allow something similar to this pattern. This is PR is what I've achieved and it can be used like this:

```python
return templates.TemplateResponse(
    "index.html.jinja2", context, block_name_list=["form", "oob_contact"]
)
```

This is my first time contributing and I'll be happy to have any feedback :)