### PR TITLE
fix litestar dependencies

### DIFF
--- a/src/jinja2_fragments/litestar.py
+++ b/src/jinja2_fragments/litestar.py
@@ -9,10 +9,10 @@ try:
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.connection import Request
     from litestar.contrib.htmx.response import HTMXTemplate
-    from litestar.contrib.htmx.types import EventAfterType, PushUrlType, ReSwapMethod
     from litestar.datastructures import Cookie
     from litestar.enums import MediaType
     from litestar.exceptions import ImproperlyConfiguredException, LitestarException
+    from litestar.plugins.htmx import EventAfterType, PushUrlType, ReSwapMethod
     from litestar.response.base import ASGIResponse
     from litestar.utils.deprecation import warn_deprecation
 except ModuleNotFoundError as e:

--- a/src/jinja2_fragments/litestar.py
+++ b/src/jinja2_fragments/litestar.py
@@ -12,9 +12,20 @@ try:
     from litestar.datastructures import Cookie
     from litestar.enums import MediaType
     from litestar.exceptions import ImproperlyConfiguredException, LitestarException
-    from litestar.plugins.htmx import EventAfterType, PushUrlType, ReSwapMethod
     from litestar.response.base import ASGIResponse
     from litestar.utils.deprecation import warn_deprecation
+
+    try:
+        # litestar>=2.13.0
+        from litestar.plugins.htmx import EventAfterType, PushUrlType, ReSwapMethod
+    except ImportError:
+        # litestar<2.13.0
+        from litestar.contrib.htmx.types import (
+            EventAfterType,
+            PushUrlType,
+            ReSwapMethod,
+        )
+
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
         "Install litestar[jinja] before using jinja_fragments.litestar"


### PR DESCRIPTION
Fixing https://github.com/sponsfreixes/jinja2-fragments/issues/36

As outlined in the issue, the import path used by `jinja2-fragments` is incomplete and deprecated. This is also demonstrated by failing tests for the current version.

Changing one line fixes it.