### PR TITLE
Fix deprecated Litestar import

### DIFF
--- a/src/jinja2_fragments/litestar.py
+++ b/src/jinja2_fragments/litestar.py
@@ -8,7 +8,6 @@ try:
     from litestar import Litestar
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.connection import Request
-    from litestar.contrib.htmx.response import HTMXTemplate
     from litestar.datastructures import Cookie
     from litestar.enums import MediaType
     from litestar.exceptions import ImproperlyConfiguredException, LitestarException
@@ -17,9 +16,15 @@ try:
 
     try:
         # litestar>=2.13.0
-        from litestar.plugins.htmx import EventAfterType, PushUrlType, ReSwapMethod
+        from litestar.plugins.htmx import (
+            EventAfterType,
+            HTMXTemplate,
+            PushUrlType,
+            ReSwapMethod,
+        )
     except ImportError:
         # litestar<2.13.0
+        from litestar.contrib.htmx.response import HTMXTemplate
         from litestar.contrib.htmx.types import (
             EventAfterType,
             PushUrlType,


### PR DESCRIPTION
Importing from `litestar.contrib.htmx.response` raises the following warning in Litestar >=2.13:

```
DeprecationWarning: Import of deprecated import 'litestar.contrib.htmx.response.HTMXTemplate'. Deprecated in litestar 2.13. This import will be removed in 3.0. importing HTMXTemplate from 'litestar.contrib.htmx.response' is deprecated, please import it from 'litestar.plugins.htmx' instead
```