### PR TITLE
Add positional request argument for starlette 0.29 and newer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ requires = [
 tests_requires = [
     "quart >= 0.18.0",
     "flask >= 2.1.0",
-    "fastapi",
+    "fastapi >= 0.108.0",
     "sanic",
     "sanic_ext",
     "sanic_testing",
-    "starlette[full]",
+    "starlette[full] >= 0.29.0",
     "pytest",
     "pytest_asyncio",
     "litestar[standard]",

--- a/src/jinja2_fragments/fastapi.py
+++ b/src/jinja2_fragments/fastapi.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import typing
+import warnings
 
 try:
     from starlette.background import BackgroundTask
+    from starlette.requests import Request
     from starlette.responses import HTMLResponse, Response
     from starlette.templating import Jinja2Templates, _TemplateResponse
 except ModuleNotFoundError as e:
@@ -19,20 +21,32 @@ class InvalidContextError(Exception):
 
 
 class Jinja2Blocks(Jinja2Templates):
-    def __init__(self, directory, **env_options):
-        super().__init__(directory, **env_options)
-
-    @typing.overload  # type: ignore
+    @typing.overload
     def TemplateResponse(
         self,
+        request: Request,
         name: str,
-        context: dict[str, typing.Any],
+        context: dict[str, typing.Any] | None = None,
         status_code: int = 200,
         headers: typing.Mapping[str, str] | None = None,
         media_type: str | None = None,
         background: BackgroundTask | None = None,
         *,
         block_names: list[str] = [],
+    ) -> Response: ...
+
+    @typing.overload
+    def TemplateResponse(
+        self,
+        request: Request,
+        name: str,
+        context: dict[str, typing.Any] | None = None,
+        status_code: int = 200,
+        headers: typing.Mapping[str, str] | None = None,
+        media_type: str | None = None,
+        background: BackgroundTask | None = None,
+        *,
+        block_name: str | None = None,
     ) -> Response: ...
 
     @typing.overload
@@ -45,9 +59,12 @@ class Jinja2Blocks(Jinja2Templates):
         media_type: str | None = None,
         background: BackgroundTask | None = None,
         *,
-        block_name: str | None = None,
-    ) -> Response: ...
+        block_names: list[str] = [],
+    ) -> Response:
+        # Deprecated, request should be given as first argument
+        ...
 
+    @typing.overload
     def TemplateResponse(
         self,
         name: str,
@@ -56,14 +73,31 @@ class Jinja2Blocks(Jinja2Templates):
         headers: typing.Mapping[str, str] | None = None,
         media_type: str | None = None,
         background: BackgroundTask | None = None,
-        **kwargs: typing.Any,
+        *,
+        block_name: str | None = None,
     ) -> Response:
-        if "request" not in context:
-            raise ValueError('context must include a "request" key')
+        # Deprecated, request should be given as first argument
+        ...
+
+    def TemplateResponse(self, *args: typing.Any, **kwargs: typing.Any) -> Response:
+        (
+            request,
+            name,
+            context,
+            status_code,
+            headers,
+            media_type,
+            background,
+        ) = self._parse_template_response_args(*args, **kwargs)
+
+        context.setdefault("request", request)
+        for context_processor in self.context_processors:
+            context.update(context_processor(request))
+
         template = self.get_template(name)
 
-        block_name = kwargs.get("block_name", None)
-        block_names = kwargs.get("block_names", [])
+        block_name: str | None = kwargs.get("block_name", None)
+        block_names: list[str] = kwargs.get("block_names", [])
 
         if block_name:
             content = render_block(
@@ -103,3 +137,71 @@ class Jinja2Blocks(Jinja2Templates):
             media_type=media_type,
             background=background,
         )
+
+    def _parse_template_response_args(
+        self, *args: typing.Any, **kwargs: typing.Any
+    ) -> tuple[
+        Request,
+        str,
+        dict[str, typing.Any],
+        int,
+        typing.Mapping[str, str],
+        str,
+        BackgroundTask,
+    ]:
+        if args:
+            if isinstance(
+                args[0], str
+            ):  # the first argument is template name (old style)
+                warnings.warn(
+                    "The `name` is not the first parameter anymore. "
+                    "The first parameter should be the `Request` instance.\n"
+                    'Replace `TemplateResponse(name, {"request": request})` by '
+                    "`TemplateResponse(request, name)`.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+                name = args[0]
+                context = args[1] if len(args) > 1 else kwargs.get("context", {})
+                status_code = (
+                    args[2] if len(args) > 2 else kwargs.get("status_code", 200)
+                )
+                headers = args[2] if len(args) > 2 else kwargs.get("headers")
+                media_type = args[3] if len(args) > 3 else kwargs.get("media_type")
+                background = args[4] if len(args) > 4 else kwargs.get("background")
+
+                if "request" not in context:
+                    raise ValueError('context must include a "request" key')
+                request = context["request"]
+            else:  # the first argument is a request instance (new style)
+                request = args[0]
+                name = args[1] if len(args) > 1 else kwargs["name"]
+                context = args[2] if len(args) > 2 else kwargs.get("context", {})
+                status_code = (
+                    args[3] if len(args) > 3 else kwargs.get("status_code", 200)
+                )
+                headers = args[4] if len(args) > 4 else kwargs.get("headers")
+                media_type = args[5] if len(args) > 5 else kwargs.get("media_type")
+                background = args[6] if len(args) > 6 else kwargs.get("background")
+        else:  # all arguments are kwargs
+            if "request" not in kwargs:
+                warnings.warn(
+                    "The `TemplateResponse` now requires the `request` argument.\n"
+                    'Replace `TemplateResponse(name, {"request": request})` by '
+                    "`TemplateResponse(request, name)`.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                if "request" not in kwargs.get("context", {}):
+                    raise ValueError('context must include a "request" key')
+
+            context = kwargs.get("context", {})
+            request = kwargs.get("request", context.get("request"))
+            name = typing.cast(str, kwargs["name"])
+            status_code = kwargs.get("status_code", 200)
+            headers = kwargs.get("headers")
+            media_type = kwargs.get("media_type")
+            background = kwargs.get("background")
+
+        return request, name, context, status_code, headers, media_type, background

--- a/src/jinja2_fragments/fastapi.py
+++ b/src/jinja2_fragments/fastapi.py
@@ -149,6 +149,17 @@ class Jinja2Blocks(Jinja2Templates):
         str,
         BackgroundTask,
     ]:
+        """Parse arguments for the `TemplateResponse` method.
+
+        Since the order of positional arguments has changed in starlette 0.29.0,
+        parsing the argument list has become more complex. To remain backwards
+        compatible, the scheme (< 0.29 or >= 0.29) must be detected.
+
+        This implementation has been extracted from starlette's codebase
+        and is used under the terms of the BSD 3-Clause License.
+
+        https://github.com/encode/starlette/blob/0.46.1/starlette/templating.py#L158
+        """
         if args:
             if isinstance(
                 args[0], str
@@ -159,7 +170,7 @@ class Jinja2Blocks(Jinja2Templates):
                     'Replace `TemplateResponse(name, {"request": request})` by '
                     "`TemplateResponse(request, name)`.",
                     DeprecationWarning,
-                    stacklevel=2,
+                    stacklevel=3,
                 )
 
                 name = args[0]
@@ -191,7 +202,7 @@ class Jinja2Blocks(Jinja2Templates):
                     'Replace `TemplateResponse(name, {"request": request})` by '
                     "`TemplateResponse(request, name)`.",
                     DeprecationWarning,
-                    stacklevel=2,
+                    stacklevel=3,
                 )
                 if "request" not in kwargs.get("context", {}):
                     raise ValueError('context must include a "request" key')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,17 +176,10 @@ def quart_client(quart_app):
 
 
 @pytest.fixture(scope="session")
-def fastapi_app():
-    from fastapi.templating import Jinja2Templates
-
+def fastapi_app(environment):
     _app = fastapi.FastAPI()
 
-    templates: Jinja2Templates = Jinja2Blocks(
-        "tests/templates",
-        autoescape=select_autoescape(("html", "jinja2")),
-        trim_blocks=True,
-        lstrip_blocks=True,
-    )
+    templates = Jinja2Blocks(env=environment)
 
     @_app.get("/")
     async def home():
@@ -200,7 +193,7 @@ def fastapi_app():
         `block_name` paramater, so the template renders normally.
         """
         page_to_render = "simple_page.html.jinja2"
-        return templates.TemplateResponse(page_to_render, {"request": request})
+        return templates.TemplateResponse(request, page_to_render)
 
     @_app.get("/simple_page_content")
     async def simple_page_content(
@@ -210,9 +203,7 @@ def fastapi_app():
         parameter, so will only render content within that block.
         """
         page_to_render = "simple_page.html.jinja2"
-        return templates.TemplateResponse(
-            page_to_render, {"request": request}, block_name="content"
-        )
+        return templates.TemplateResponse(request, page_to_render, block_name="content")
 
     @_app.get("/nested_content")
     async def nested_content(request: fastapi.requests.Request):
@@ -222,8 +213,9 @@ def fastapi_app():
         """
         page_to_render = "nested_blocks_and_variables.html.jinja2"
         return templates.TemplateResponse(
+            request,
             page_to_render,
-            {"request": request, "name": NAME, "lucky_number": LUCKY_NUMBER},
+            {"name": NAME, "lucky_number": LUCKY_NUMBER},
             block_name="content",
         )
 
@@ -235,8 +227,9 @@ def fastapi_app():
         """
         page_to_render = "nested_blocks_and_variables.html.jinja2"
         return templates.TemplateResponse(
+            request,
             page_to_render,
-            {"request": request, "lucky_number": LUCKY_NUMBER},
+            {"lucky_number": LUCKY_NUMBER},
             block_name="inner",
         )
 
@@ -249,8 +242,9 @@ def fastapi_app():
         """
         page_to_render = "nested_blocks_and_variables.html.jinja2"
         return templates.TemplateResponse(
+            request,
             page_to_render,
-            {"request": request, "lucky_number": LUCKY_NUMBER},
+            {"lucky_number": LUCKY_NUMBER},
             block_name="inner",
         )
 
@@ -263,8 +257,9 @@ def fastapi_app():
         """
         page_to_render = "multiple_blocks.html.jinja2"
         return templates.TemplateResponse(
+            request,
             page_to_render,
-            {"request": request, "name": NAME, "lucky_number": LUCKY_NUMBER},
+            {"name": NAME, "lucky_number": LUCKY_NUMBER},
             block_names=["content", "additional_content"],
         )
 
@@ -272,7 +267,9 @@ def fastapi_app():
     async def invalid_block(request: fastapi.requests.Request):
         """Decorator wraps around route method and includes an unexisting block name."""
         return templates.TemplateResponse(
-            "simple_page.html.jinja2", {"request": request}, block_name="invalid_block"
+            request,
+            "simple_page.html.jinja2",
+            block_name="invalid_block",
         )
 
     @_app.get("/invalid_block_list")
@@ -280,8 +277,8 @@ def fastapi_app():
         """Decorator wraps around route method and includes an unexisting block name
         passed as a list argument."""
         return templates.TemplateResponse(
+            request,
             "simple_page.html.jinja2",
-            {"request": request},
             block_names=["invalid_block"],
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,22 +188,36 @@ def fastapi_app(environment):
     @_app.get("/simple_page")
     async def simple_page(
         request: fastapi.requests.Request,
+        pass_request_via_context: bool = False,
     ):
         """Decorator wraps around route method, but does not define a
         `block_name` paramater, so the template renders normally.
         """
         page_to_render = "simple_page.html.jinja2"
-        return templates.TemplateResponse(request, page_to_render)
+        if pass_request_via_context:
+            return templates.TemplateResponse(
+                page_to_render, context={"request": request}
+            )
+        else:
+            return templates.TemplateResponse(request, page_to_render)
 
     @_app.get("/simple_page_content")
     async def simple_page_content(
         request: fastapi.requests.Request,
+        pass_request_via_context: bool = False,
     ):
         """Decorator wraps around route method and includes `block_name`
         parameter, so will only render content within that block.
         """
         page_to_render = "simple_page.html.jinja2"
-        return templates.TemplateResponse(request, page_to_render, block_name="content")
+        if pass_request_via_context:
+            return templates.TemplateResponse(
+                name=page_to_render, context={"request": request}, block_name="content"
+            )
+        else:
+            return templates.TemplateResponse(
+                request=request, name=page_to_render, block_name="content"
+            )
 
     @_app.get("/nested_content")
     async def nested_content(request: fastapi.requests.Request):

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -78,3 +78,27 @@ class TestFastAPIRenderBlock:
 
         assert exc.value.block_name == "invalid_block"
         assert exc.value.template_name == "simple_page.html.jinja2"
+
+    def test_deprecation_warning_simple_page(self, fastapi_client, get_html):
+        with pytest.warns(DeprecationWarning) as record:
+            response = fastapi_client.get(
+                "/simple_page", params={"pass_request_via_context": True}
+            )
+
+        assert len(record) == 1
+        assert "conftest.py" in record[0].filename
+
+        html = get_html("simple_page.html")
+        assert html == response.text
+
+    def test_deprecation_warning_simple_page_content(self, fastapi_client, get_html):
+        with pytest.warns(DeprecationWarning) as record:
+            response = fastapi_client.get(
+                "/simple_page_content", params={"pass_request_via_context": True}
+            )
+
+        assert len(record) == 1
+        assert "conftest.py" in record[0].filename
+
+        html = get_html("simple_page_content.html")
+        assert html == response.text


### PR DESCRIPTION
Closes #39

## Summary by Sourcery

Adapt the FastAPI integration to support the new positional request argument introduced in Starlette 0.29, while maintaining backward compatibility with older versions. This involves adjusting the argument parsing logic within the TemplateResponse method to accommodate the change in argument order.

Enhancements:
- Adapt argument parsing in TemplateResponse to handle the new positional request argument in Starlette 0.29, ensuring backward compatibility.
- Update the fastapi_app fixture in tests to align with the changes in TemplateResponse argument handling.
- Add deprecation warnings when the request argument is not passed as the first argument to TemplateResponse.
- Update the test suite to include tests that trigger the deprecation warnings when using the old argument order for TemplateResponse, ensuring that the warnings are displayed correctly and that the functionality remains consistent.
- Update fastapi and starlette dependencies to the latest versions.