### PR TITLE
Add blacken-docs for documentation code block formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,7 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: 1.20.0
+    hooks:
+      - id: blacken-docs

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ from jinja2_fragments import render_block
 
 environment = Environment(
     loader=FileSystemLoader("my_templates"),
-    autoescape=select_autoescape(("html", "jinja2"))
+    autoescape=select_autoescape(("html", "jinja2")),
 )
 rendered_html = render_block(
     environment, "page.html.jinja2", "content", magic_number=42
@@ -85,6 +85,7 @@ from jinja2_fragments.flask import render_block
 
 app = Flask(__name__)
 
+
 @app.get("/full_page")
 def full_page():
     return render_template("page.html.jinja2", magic_number=42)
@@ -105,6 +106,7 @@ from quart import Quart, render_template
 from jinja2_fragments.quart import render_block
 
 app = Quart(__name__)
+
 
 @app.get("/full_page")
 async def full_page():
@@ -129,20 +131,16 @@ from jinja2_fragments.starlette import Jinja2Blocks
 
 templates = Jinja2Blocks(directory="path/to/templates")
 
+
 async def full_page(request: Request):
-    return templates.TemplateResponse(
-        request,
-        "page.html.jinja2",
-        {"magic_number": 42}
-    )
+    return templates.TemplateResponse(request, "page.html.jinja2", {"magic_number": 42})
+
 
 async def only_content(request: Request):
     return templates.TemplateResponse(
-        request,
-        "page.html.jinja2",
-        {"magic_number": 42},
-        block_name="content"
+        request, "page.html.jinja2", {"magic_number": 42}, block_name="content"
     )
+
 
 routes = [
     Route("/full_page", full_page),
@@ -169,21 +167,16 @@ app = FastAPI()
 
 templates = Jinja2Blocks(directory="path/to/templates")
 
+
 @app.get("/full_page")
 async def full_page(request: Request):
-    return templates.TemplateResponse(
-        request,
-        "page.html.jinja2",
-        {"magic_number": 42}
-    )
+    return templates.TemplateResponse(request, "page.html.jinja2", {"magic_number": 42})
+
 
 @app.get("/only_content")
 async def only_content(request: Request):
     return templates.TemplateResponse(
-        request,
-        "page.html.jinja2",
-        {"magic_number": 42},
-        block_name="content"
+        request, "page.html.jinja2", {"magic_number": 42}, block_name="content"
     )
 ```
 
@@ -198,21 +191,18 @@ import sanic_ext
 from jinja2_fragments.sanic import render
 
 app = Sanic(__name__)
-app.extend(config=sanic_ext.Config(templating_path_to_templates='path/to/templates'))
+app.extend(config=sanic_ext.Config(templating_path_to_templates="path/to/templates"))
 
-@app.get('/full_page')
+
+@app.get("/full_page")
 async def full_page(request: Request):
-    return await render(
-        'page.html.jinja2', 
-        context={"magic_number": 42}
-    )
+    return await render("page.html.jinja2", context={"magic_number": 42})
+
 
 @app.get("/only_content")
 async def only_content(request: Request):
     return await render(
-        'page.html.jinja2',
-        block='content',
-        context={"magic_number": 42}
+        "page.html.jinja2", block="content", context={"magic_number": 42}
     )
 ```
 
@@ -239,20 +229,21 @@ from litestar.template.config import TemplateConfig
 from jinja2_fragments.litestar import HTMXBlockTemplate
 
 
-@get('/full_page')
+@get("/full_page")
 def full_page(request: HTMXRequest) -> Template:
     return HTMXBlockTemplate(
-        template_name='page.html.jinja2',
-        context={"magic_number": 42}
+        template_name="page.html.jinja2", context={"magic_number": 42}
     )
 
-@get('/only_content')
+
+@get("/only_content")
 def only_content(request: HTMXRequest) -> Template:
     return HTMXBlockTemplate(
-        template_name='page.html.jinja2',
-        block_name='content',
-        context={"magic_number": 42}
+        template_name="page.html.jinja2",
+        block_name="content",
+        context={"magic_number": 42},
     )
+
 
 app = Litestar(
     route_handlers=[full_page, only_content],
@@ -260,14 +251,14 @@ app = Litestar(
     template_config=TemplateConfig(
         directory="path/to/templates",
         engine=JinjaTemplateEngine,
-    )
+    ),
 )
 ```
 
 
 ## How to collaborate
 
-This project uses pre-commit hooks to run Ruff on each commit.
+This project uses pre-commit hooks to run Ruff and format Python code examples in documentation with `blacken-docs` on each commit.
 To have that running automatically on your environment, install the project with:
 
 ```shell
@@ -280,7 +271,7 @@ And then run once:
 pre-commit install
 ```
 
-From now on, every time you commit your files on this project, they will be automatically processed by Ruff.
+From now on, every time you commit your files on this project, they will be automatically processed by Ruff and `blacken-docs`.
 
 ## How to run tests
 

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -50,7 +50,7 @@ If you want to render only the ``content`` block, you can use ``render_block`` l
 
     environment = Environment(
         loader=FileSystemLoader("my_templates"),
-        autoescape=select_autoescape(("html", "jinja2"))
+        autoescape=select_autoescape(("html", "jinja2")),
     )
     rendered_html = render_block(
         environment, "page.html.jinja2", "content", magic_number=42
@@ -78,7 +78,7 @@ Jinja2 Fragments also allows you to render multiple blocks at once with the ``re
 
     environment = Environment(
         loader=FileSystemLoader("my_templates"),
-        autoescape=select_autoescape(("html", "jinja2"))
+        autoescape=select_autoescape(("html", "jinja2")),
     )
     rendered_html = render_blocks(
         environment, "page.html.jinja2", ["header", "content"], magic_number=42

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -56,7 +56,7 @@ We use ``pytest`` for testing. To run the tests:
 Pre-commit Hooks
 ================
 
-We use ``pre-commit`` hooks to run `Ruff <https://docs.astral.sh/ruff/>`_ automatically before each commit. Make sure to install them before commiting.
+We use ``pre-commit`` hooks to run `Ruff <https://docs.astral.sh/ruff/>`_ and ``blacken-docs`` automatically before each commit. Make sure to install them before commiting.
 The hooks are configured in the ``.pre-commit-config.yaml`` file.
 
 Additionally, you can run the pre-commit hooks manually against all files:

--- a/docs/source/framework_integrations.rst
+++ b/docs/source/framework_integrations.rst
@@ -29,6 +29,7 @@ To use Jinja2 Fragments with Flask, import ``render_block`` from the ``jinja2_fr
 
    app = Flask(__name__)
 
+
    @app.get("/full_page")
    def full_page():
        return render_template("page.html.jinja2", magic_number=42)
@@ -51,6 +52,7 @@ You can also use the ``render_blocks`` function (plural) to render multiple bloc
 
    from jinja2_fragments.flask import render_blocks
 
+
    @app.get("/multiple_blocks")
    def multiple_blocks():
        return render_blocks("page.html.jinja2", ["header", "content"], magic_number=42)
@@ -70,6 +72,7 @@ To use Jinja2 Fragments with Quart, import ``render_block`` from the ``jinja2_fr
    from jinja2_fragments.quart import render_block
 
    app = Quart(__name__)
+
 
    @app.get("/full_page")
    async def full_page():
@@ -107,20 +110,16 @@ To use Jinja2 Fragments with Starlette, import ``Jinja2Blocks`` from the ``jinja
 
    templates = Jinja2Blocks(directory="path/to/templates")
 
+
    async def full_page(request: Request):
-       return templates.TemplateResponse(
-           request,
-           "page.html.jinja2",
-           {"magic_number": 42}
-       )
+       return templates.TemplateResponse(request, "page.html.jinja2", {"magic_number": 42})
+
 
    async def only_content(request: Request):
        return templates.TemplateResponse(
-           request,
-           "page.html.jinja2",
-           {"magic_number": 42},
-           block_name="content"
+           request, "page.html.jinja2", {"magic_number": 42}, block_name="content"
        )
+
 
    routes = [
        Route("/full_page", full_page),
@@ -151,21 +150,16 @@ To use Jinja2 Fragments with FastAPI, import ``Jinja2Blocks`` from the ``jinja2_
 
    templates = Jinja2Blocks(directory="path/to/templates")
 
+
    @app.get("/full_page")
    async def full_page(request: Request):
-       return templates.TemplateResponse(
-           request,
-           "page.html.jinja2",
-           {"magic_number": 42}
-       )
+       return templates.TemplateResponse(request, "page.html.jinja2", {"magic_number": 42})
+
 
    @app.get("/only_content")
    async def only_content(request: Request):
        return templates.TemplateResponse(
-           request,
-           "page.html.jinja2",
-           {"magic_number": 42},
-           block_name="content"
+           request, "page.html.jinja2", {"magic_number": 42}, block_name="content"
        )
 
 The ``Jinja2Blocks`` class works exactly like FastAPI's ``Jinja2Templates``, but allows you to include an optional ``block_name`` parameter to the ``TemplateResponse`` method.
@@ -187,21 +181,18 @@ To use Jinja2 Fragments with Sanic, import ``render`` from the ``jinja2_fragment
    from jinja2_fragments.sanic import render
 
    app = Sanic(__name__)
-   app.extend(config=sanic_ext.Config(templating_path_to_templates='path/to/templates'))
+   app.extend(config=sanic_ext.Config(templating_path_to_templates="path/to/templates"))
 
-   @app.get('/full_page')
+
+   @app.get("/full_page")
    async def full_page(request: Request):
-       return await render(
-           'page.html.jinja2',
-           context={"magic_number": 42}
-       )
+       return await render("page.html.jinja2", context={"magic_number": 42})
+
 
    @app.get("/only_content")
    async def only_content(request: Request):
        return await render(
-           'page.html.jinja2',
-           block='content',
-           context={"magic_number": 42}
+           "page.html.jinja2", block="content", context={"magic_number": 42}
        )
 
 The ``render`` function is a drop-in replacement for Sanic's template extension's ``render()``. Your request context and environment configuration will work the same as before.
@@ -234,7 +225,7 @@ To use Jinja2 Fragments with Litestar, import ``HTMXBlockTemplate`` from the ``j
    except ImportError:
        # litestar<2.13.0
        from litestar.contrib.htmx.request import HTMXRequest
-   
+
    from litestar import get, Litestar
    from litestar.response import Template
 
@@ -243,20 +234,21 @@ To use Jinja2 Fragments with Litestar, import ``HTMXBlockTemplate`` from the ``j
    from jinja2_fragments.litestar import HTMXBlockTemplate
 
 
-   @get('/full_page')
+   @get("/full_page")
    def full_page(request: HTMXRequest) -> Template:
        return HTMXBlockTemplate(
-           template_name='page.html.jinja2',
-           context={"magic_number": 42}
+           template_name="page.html.jinja2", context={"magic_number": 42}
        )
 
-   @get('/only_content')
+
+   @get("/only_content")
    def only_content(request: HTMXRequest) -> Template:
        return HTMXBlockTemplate(
-           template_name='page.html.jinja2',
-           block_name='content',
-           context={"magic_number": 42}
+           template_name="page.html.jinja2",
+           block_name="content",
+           context={"magic_number": 42},
        )
+
 
    app = Litestar(
        route_handlers=[full_page, only_content],
@@ -264,7 +256,7 @@ To use Jinja2 Fragments with Litestar, import ``HTMXBlockTemplate`` from the ``j
        template_config=TemplateConfig(
            directory="path/to/templates",
            engine=JinjaTemplateEngine,
-       )
+       ),
    )
 
 .. note::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -85,7 +85,7 @@ You can render only the ``content`` block with:
 
     environment = Environment(
         loader=FileSystemLoader("my_templates"),
-        autoescape=select_autoescape(("html", "jinja2"))
+        autoescape=select_autoescape(("html", "jinja2")),
     )
     rendered_html = render_block(
         environment, "page.html.jinja2", "content", magic_number=42
@@ -115,13 +115,15 @@ Each framework has its own integration patterns:
 
          app = Flask(__name__)
 
-         @app.route('/profile/<username>')
-         def profile(username):
-             return render_template('profile.html.jinja2', username=username)
 
-         @app.route('/profile/<username>/details')
+         @app.route("/profile/<username>")
+         def profile(username):
+             return render_template("profile.html.jinja2", username=username)
+
+
+         @app.route("/profile/<username>/details")
          def profile_details(username):
-             return render_block('profile.html.jinja2', 'details', username=username)
+             return render_block("profile.html.jinja2", "details", username=username)
 
    .. tab:: Quart
 
@@ -132,13 +134,15 @@ Each framework has its own integration patterns:
 
          app = Quart(__name__)
 
-         @app.route('/profile/<username>')
-         async def profile(username):
-             return await render_template('profile.html.jinja2', username=username)
 
-         @app.route('/profile/<username>/details')
+         @app.route("/profile/<username>")
+         async def profile(username):
+             return await render_template("profile.html.jinja2", username=username)
+
+
+         @app.route("/profile/<username>/details")
          async def profile_details(username):
-             return await render_block('profile.html.jinja2', 'details', username=username)
+             return await render_block("profile.html.jinja2", "details", username=username)
 
    .. tab:: Starlette
 
@@ -151,26 +155,24 @@ Each framework has its own integration patterns:
 
          templates = Jinja2Blocks(directory="templates")
 
+
          async def profile(request: Request):
              username = request.path_params["username"]
              return templates.TemplateResponse(
-                request,
-                'profile.html.jinja2',
-                {"username": username}
-                )
+                 request, "profile.html.jinja2", {"username": username}
+             )
+
 
          async def profile_details(request: Request):
              username = request.path_params["username"]
              return templates.TemplateResponse(
-                 request,
-                 'profile.html.jinja2',
-                 {"username": username},
-                 block_name="details"
+                 request, "profile.html.jinja2", {"username": username}, block_name="details"
              )
 
+
          routes = [
-             Route('/profile/{username}', profile),
-             Route('/profile/{username}/details', profile_details),
+             Route("/profile/{username}", profile),
+             Route("/profile/{username}/details", profile_details),
          ]
          app = Starlette(routes=routes)
 
@@ -184,21 +186,18 @@ Each framework has its own integration patterns:
          app = FastAPI()
          templates = Jinja2Blocks(directory="templates")
 
-         @app.get('/profile/{username}')
+
+         @app.get("/profile/{username}")
          def profile(request: Request, username: str):
              return templates.TemplateResponse(
-                request,
-                'profile.html.jinja2',
-                {"username": username}
-                )
+                 request, "profile.html.jinja2", {"username": username}
+             )
 
-         @app.get('/profile/{username}/details')
+
+         @app.get("/profile/{username}/details")
          def profile_details(request: Request, username: str):
              return templates.TemplateResponse(
-                 request,
-                 'profile.html.jinja2',
-                 {"username": username},
-                 block_name="details"
+                 request, "profile.html.jinja2", {"username": username}, block_name="details"
              )
 
    .. tab:: Sanic
@@ -210,17 +209,18 @@ Each framework has its own integration patterns:
         from jinja2_fragments.sanic import render
 
         app = Sanic(__name__)
-        app.extend(config=sanic_ext.Config(templating_path_to_templates='path/to/templates'))
+        app.extend(config=sanic_ext.Config(templating_path_to_templates="path/to/templates"))
 
-        @app.route('/profile/<username>')
+
+        @app.route("/profile/<username>")
         async def profile(request: Request, username: str):
-            return await render('profile.html.jinja2', context={"username": username}
-            )
+            return await render("profile.html.jinja2", context={"username": username})
 
-        @app.route('/profile/<username>/details')
+
+        @app.route("/profile/<username>/details")
         async def profile_details(request: Request, username: str):
             return await render(
-                'profile.html.jinja2', block='content', context={"username": username}
+                "profile.html.jinja2", block="content", context={"username": username}
             )
 
    .. tab:: Litestar
@@ -233,7 +233,7 @@ Each framework has its own integration patterns:
         except ImportError:
             # litestar<2.13.0
             from litestar.contrib.htmx.request import HTMXRequest
-        
+
         from litestar import get, Litestar
         from litestar.response import Template
 
@@ -242,27 +242,29 @@ Each framework has its own integration patterns:
         from jinja2_fragments.litestar import HTMXBlockTemplate
 
 
-        @get('/profile/{username:str}')
+        @get("/profile/{username:str}")
         def profile(request: HTMXRequest, username: str) -> Template:
             return HTMXBlockTemplate(
-                template_name='profile.html.jinja2',
-                context={"username": username}
+                template_name="profile.html.jinja2", context={"username": username}
             )
 
-        @get('/profile/{username:str}/details')
-        def profile_details(request: HTMXRequest, username:str) -> Template:
+
+        @get("/profile/{username:str}/details")
+        def profile_details(request: HTMXRequest, username: str) -> Template:
             return HTMXBlockTemplate(
-                template_name='profile.html.jinja2',
-                block_name='details',
-                context={"username": username}
+                template_name="profile.html.jinja2",
+                block_name="details",
+                context={"username": username},
             )
+
 
         app = Litestar(
             route_handlers=[profile, profile_details],
             request_class=HTMXRequest,
             template_config=TemplateConfig(
-                directory="path/to/templates", engine=JinjaTemplateEngine,
-            )
+                directory="path/to/templates",
+                engine=JinjaTemplateEngine,
+            ),
         )
 
       .. note::


### PR DESCRIPTION
## Summary
- Add `blacken-docs` pre-commit hook pinned to `1.20.0`
- Update contributor docs to mention `blacken-docs` alongside Ruff
- Apply `blacken-docs` formatting to existing Python code examples in docs/README

## Validation
- `/tmp/oz-precommit-venv/bin/pre-commit run --all-files`

_Conversation: https://app.warp.dev/conversation/5df66b2d-bd2c-4da1-9fa7-3df74db785aa_
_Run: https://oz.warp.dev/runs/019d4beb-8df0-79f7-a619-d4e2a6b405a2_
Co-Authored-By: Oz <oz-agent@warp.dev>
_This PR was generated with [Oz](https://warp.dev/oz)._

## Summary by Sourcery

Add automated formatting for Python code examples in documentation and apply it across existing docs.

Enhancements:
- Format existing README and documentation Python code examples for consistency and style.

Build:
- Configure a new pre-commit hook using blacken-docs pinned to version 1.20.0 to format documentation code blocks.

Documentation:
- Update contributor documentation to mention blacken-docs alongside Ruff and clarify that documentation code examples are auto-formatted.