### PR TITLE
ci: add Python 3.14 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- add Python 3.14 to the GitHub Actions test matrix in `.github/workflows/ci.yml`

## Testing
- not run (CI configuration-only change)

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://app.warp.dev/conversation/a0813aab-d7e8-4e24-afa0-e783ecce3824_
_Run: https://oz.warp.dev/runs/019d4c04-13df-779d-a012-b8e19c17e165_

_This PR was generated with [Oz](https://warp.dev/oz)._

## Summary by Sourcery

CI:
- Add Python 3.14 to the GitHub Actions test matrix for running CI.