### PR TITLE
feat: add render_block/render_blocks as Jinja2 template globals

### DIFF
--- a/docs/source/api/core.rst
+++ b/docs/source/api/core.rst
@@ -5,6 +5,6 @@ Core API
 The core of jinja2-fragments provides functionality to render individual blocks from Jinja2 templates.
 
 .. automodule:: jinja2_fragments
-   :members: render_block, render_blocks
+   :members: render_block, render_blocks, setup_globals
    :undoc-members:
    :show-inheritance:

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -87,3 +87,44 @@ Jinja2 Fragments also allows you to render multiple blocks at once with the ``re
 .. note::
    Rendering multiple blocks is particularly useful for implementing `out-of-band updates <https://htmx.org/attributes/hx-swap-oob/>`_ 
    when using htmx, allowing you to update multiple parts of a page in a single request.
+
+Rendering Blocks from Within Templates
+======================================
+
+You can also call ``render_block`` and ``render_blocks`` directly from within
+Jinja2 template expressions. This is useful when a template needs to compose
+fragments from other template files.
+
+To enable this, call :func:`~jinja2_fragments.setup_globals` on your Jinja2
+environment:
+
+.. code-block:: python
+
+    from jinja2 import Environment, FileSystemLoader, select_autoescape
+    from jinja2_fragments import setup_globals
+
+    environment = Environment(
+        loader=FileSystemLoader("my_templates"),
+        autoescape=select_autoescape(("html", "jinja2")),
+    )
+    setup_globals(environment)
+
+Once installed, you can use ``render_block`` and ``render_blocks`` in any
+template rendered with that environment:
+
+.. code-block:: html
+
+    <div id="customer">
+      {{ render_block("customer/edit.html.jinja2", "customer", customer=invoice.customer) }}
+    </div>
+
+    {# Render multiple blocks at once #}
+    {{ render_blocks("dashboard.html.jinja2", ["stats", "chart"], user=user) }}
+
+The current template context is automatically forwarded to the rendered block(s).
+Any keyword arguments you pass will override individual context variables.
+
+.. note::
+   ``setup_globals`` automatically selects the correct sync or async
+   implementation based on ``environment.is_async``, so it works with both
+   synchronous and asynchronous environments.

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -128,3 +128,4 @@ Any keyword arguments you pass will override individual context variables.
    ``setup_globals`` automatically selects the correct sync or async
    implementation based on ``environment.is_async``, so it works with both
    synchronous and asynchronous environments.
+   Existing globals named ``render_block`` and ``render_blocks`` are preserved.

--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -51,7 +51,7 @@ async def render_block_async(
 async def render_blocks_async(
     environment: Environment,
     template_name: str,
-    block_names: list[str],
+    block_names: typing.Sequence[str],
     *args: typing.Any,
     **kwargs: typing.Any,
 ) -> str:
@@ -136,7 +136,7 @@ def render_block(
 def render_blocks(
     environment: Environment,
     template_name: str,
-    block_names: list[str],
+    block_names: typing.Sequence[str],
     *args: typing.Any,
     **kwargs: typing.Any,
 ) -> str:
@@ -150,7 +150,7 @@ def render_blocks(
     Args:
         template_name: The name of the Jinja2 template file. This should
             include only the template file's name, without the path.
-        block_names: A list of block names from the template that you
+        block_names: A sequence of block names from the template that you
             want to render. These blocks are rendered sequentially in the
             given order.
         **context: Additional variables passed as context for rendering
@@ -193,7 +193,7 @@ def render_blocks(
 def _render_template_blocks(
     environment: Environment,
     template_name: str,
-    block_names: list[str],
+    block_names: typing.Sequence[str],
     *args: typing.Any,
     **kwargs: typing.Any,
 ) -> str:
@@ -217,7 +217,7 @@ def _render_template_blocks(
 async def _render_template_blocks_async(
     environment: Environment,
     template_name: str,
-    block_names: list[str],
+    block_names: typing.Sequence[str],
     *args: typing.Any,
     **kwargs: typing.Any,
 ) -> str:
@@ -277,7 +277,7 @@ def _render_block_callable(
 def _render_blocks_callable(
     context: Context,
     template_name: str,
-    block_names: list[str],
+    block_names: typing.Sequence[str],
     **kwargs: typing.Any,
 ) -> Markup:
     """Jinja2 template global that renders multiple blocks from another template.
@@ -309,7 +309,7 @@ async def _async_render_block_callable(
 async def _async_render_blocks_callable(
     context: Context,
     template_name: str,
-    block_names: list[str],
+    block_names: typing.Sequence[str],
     **kwargs: typing.Any,
 ) -> Markup:
     """Async version of :func:`_render_blocks_callable`."""
@@ -337,13 +337,14 @@ def setup_globals(environment: Environment) -> None:
 
     The correct sync or async callable is chosen based on
     ``environment.is_async``.
+    Existing globals named ``render_block`` and ``render_blocks`` are preserved.
 
     Args:
         environment: The Jinja2 :class:`~jinja2.Environment` to modify.
     """
     if environment.is_async:
-        environment.globals["render_block"] = _async_render_block_callable
-        environment.globals["render_blocks"] = _async_render_blocks_callable
+        environment.globals.setdefault("render_block", _async_render_block_callable)
+        environment.globals.setdefault("render_blocks", _async_render_blocks_callable)
     else:
-        environment.globals["render_block"] = _render_block_callable
-        environment.globals["render_blocks"] = _render_blocks_callable
+        environment.globals.setdefault("render_block", _render_block_callable)
+        environment.globals.setdefault("render_blocks", _render_blocks_callable)

--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -270,9 +270,7 @@ def _render_block_callable(
     overridden with keyword arguments.
     """
     merged = {**context.get_all(), **kwargs}
-    return Markup(
-        render_block(context.environment, template_name, block_name, merged)
-    )
+    return Markup(render_block(context.environment, template_name, block_name, merged))
 
 
 @pass_context
@@ -303,9 +301,7 @@ async def _async_render_block_callable(
     """Async version of :func:`_render_block_callable`."""
     merged = {**context.get_all(), **kwargs}
     return Markup(
-        await render_block_async(
-            context.environment, template_name, block_name, merged
-        )
+        await render_block_async(context.environment, template_name, block_name, merged)
     )
 
 

--- a/src/jinja2_fragments/__init__.py
+++ b/src/jinja2_fragments/__init__.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import typing
 from asyncio import AbstractEventLoop
 
-from jinja2 import Environment
+from jinja2 import Environment, pass_context
+from jinja2.runtime import Context
+from markupsafe import Markup
 
 
 class BlockNotFoundError(Exception):
@@ -253,3 +255,99 @@ def _get_loop() -> tuple[AbstractEventLoop, bool]:
     except RuntimeError:
         close = True
         return (asyncio.new_event_loop(), close)
+
+
+@pass_context
+def _render_block_callable(
+    context: Context,
+    template_name: str,
+    block_name: str,
+    **kwargs: typing.Any,
+) -> Markup:
+    """Jinja2 template global that renders a single block from another template.
+
+    The current template context is forwarded to the target block and can be
+    overridden with keyword arguments.
+    """
+    merged = {**context.get_all(), **kwargs}
+    return Markup(
+        render_block(context.environment, template_name, block_name, merged)
+    )
+
+
+@pass_context
+def _render_blocks_callable(
+    context: Context,
+    template_name: str,
+    block_names: list[str],
+    **kwargs: typing.Any,
+) -> Markup:
+    """Jinja2 template global that renders multiple blocks from another template.
+
+    The current template context is forwarded to the target blocks and can be
+    overridden with keyword arguments.
+    """
+    merged = {**context.get_all(), **kwargs}
+    return Markup(
+        render_blocks(context.environment, template_name, block_names, merged)
+    )
+
+
+@pass_context
+async def _async_render_block_callable(
+    context: Context,
+    template_name: str,
+    block_name: str,
+    **kwargs: typing.Any,
+) -> Markup:
+    """Async version of :func:`_render_block_callable`."""
+    merged = {**context.get_all(), **kwargs}
+    return Markup(
+        await render_block_async(
+            context.environment, template_name, block_name, merged
+        )
+    )
+
+
+@pass_context
+async def _async_render_blocks_callable(
+    context: Context,
+    template_name: str,
+    block_names: list[str],
+    **kwargs: typing.Any,
+) -> Markup:
+    """Async version of :func:`_render_blocks_callable`."""
+    merged = {**context.get_all(), **kwargs}
+    return Markup(
+        await render_blocks_async(
+            context.environment, template_name, block_names, merged
+        )
+    )
+
+
+def setup_globals(environment: Environment) -> None:
+    """Install ``render_block`` and ``render_blocks`` as Jinja2 template globals.
+
+    After calling this function, templates rendered with *environment* can use
+    ``render_block`` and ``render_blocks`` directly in expressions:
+
+    .. code-block:: jinja
+
+        {{ render_block("other_template.html", "block_name", key=value) }}
+        {{ render_blocks("other_template.html", ["block_a", "block_b"], key=value) }}
+
+    The current template context is automatically forwarded; extra keyword
+    arguments override individual context variables.
+
+    The correct sync or async callable is chosen based on
+    ``environment.is_async``.
+
+    Args:
+        environment: The Jinja2 :class:`~jinja2.Environment` to modify.
+    """
+    if environment.is_async:
+        environment.globals["render_block"] = _async_render_block_callable
+        environment.globals["render_blocks"] = _async_render_blocks_callable
+    else:
+        environment.globals["render_block"] = _render_block_callable
+        environment.globals["render_blocks"] = _render_blocks_callable

--- a/tests/rendered_templates/include_block.html
+++ b/tests/rendered_templates/include_block.html
@@ -1,0 +1,3 @@
+<div>
+    <p>This is the bottom paragraph. Lucky number: 42</p>
+</div>

--- a/tests/rendered_templates/include_block_auto_context.html
+++ b/tests/rendered_templates/include_block_auto_context.html
@@ -1,0 +1,3 @@
+<div>
+    <p>This is the bottom paragraph. Lucky number: 42</p>
+</div>

--- a/tests/rendered_templates/include_block_override.html
+++ b/tests/rendered_templates/include_block_override.html
@@ -1,0 +1,3 @@
+<div>
+    <p>This is the bottom paragraph. Lucky number: 99</p>
+</div>

--- a/tests/rendered_templates/include_blocks.html
+++ b/tests/rendered_templates/include_blocks.html
@@ -1,0 +1,4 @@
+<div>
+    <p>This is the content. Hello Guido!</p>
+    <p>Lucky number: 42</p>
+</div>

--- a/tests/templates/include_block.html.jinja2
+++ b/tests/templates/include_block.html.jinja2
@@ -1,0 +1,2 @@
+<div>
+{{ render_block("nested_blocks_and_variables.html.jinja2", "inner", lucky_number=lucky_number) }}</div>

--- a/tests/templates/include_block_auto_context.html.jinja2
+++ b/tests/templates/include_block_auto_context.html.jinja2
@@ -1,0 +1,2 @@
+<div>
+{{ render_block("nested_blocks_and_variables.html.jinja2", "inner") }}</div>

--- a/tests/templates/include_block_override.html.jinja2
+++ b/tests/templates/include_block_override.html.jinja2
@@ -1,0 +1,2 @@
+<div>
+{{ render_block("nested_blocks_and_variables.html.jinja2", "inner", lucky_number="99") }}</div>

--- a/tests/templates/include_blocks.html.jinja2
+++ b/tests/templates/include_blocks.html.jinja2
@@ -1,0 +1,2 @@
+<div>
+{{ render_blocks("multiple_blocks.html.jinja2", ["content", "additional_content"], name=name, lucky_number=lucky_number) }}</div>

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -45,7 +45,7 @@ class TestTemplateGlobals:
     templates via setup_globals.
     """
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(autouse=True, scope="class")
     def _setup(self, environment):
         setup_globals(environment)
         yield
@@ -82,7 +82,7 @@ class TestTemplateGlobals:
 class TestAsyncTemplateGlobals:
     """Async variants of TestTemplateGlobals."""
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(autouse=True, scope="class")
     def _setup(self, async_environment):
         setup_globals(async_environment)
         yield

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -7,6 +7,7 @@ from jinja2_fragments import (
     render_block_async,
     render_blocks,
     render_blocks_async,
+    setup_globals,
 )
 
 
@@ -37,6 +38,88 @@ class TestFullpage:
 
         html = get_html(html_name)
         assert html == rendered
+
+
+class TestTemplateGlobals:
+    """Test render_block / render_blocks called from within
+    templates via setup_globals.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, environment):
+        setup_globals(environment)
+        yield
+        # Clean up globals so other tests are unaffected
+        environment.globals.pop("render_block", None)
+        environment.globals.pop("render_blocks", None)
+
+    def test_render_block_global(self, environment, get_html):
+        """Test single-block rendering via template global with explicit kwargs."""
+        template = environment.get_template("include_block.html.jinja2")
+        rendered = template.render(lucky_number=LUCKY_NUMBER)
+        assert rendered == get_html("include_block.html")
+
+    def test_render_blocks_global(self, environment, get_html):
+        """Test multi-block rendering via template global."""
+        template = environment.get_template("include_blocks.html.jinja2")
+        rendered = template.render(name=NAME, lucky_number=LUCKY_NUMBER)
+        assert rendered == get_html("include_blocks.html")
+
+    def test_auto_context_forwarding(self, environment, get_html):
+        """Test that the parent template context is automatically forwarded."""
+        template = environment.get_template("include_block_auto_context.html.jinja2")
+        rendered = template.render(lucky_number=LUCKY_NUMBER)
+        assert rendered == get_html("include_block_auto_context.html")
+
+    def test_kwargs_override_context(self, environment, get_html):
+        """Test that kwargs passed in the template override the parent context."""
+        template = environment.get_template("include_block_override.html.jinja2")
+        # Parent context has lucky_number="42", but template overrides with "99"
+        rendered = template.render(lucky_number=LUCKY_NUMBER)
+        assert rendered == get_html("include_block_override.html")
+
+
+class TestAsyncTemplateGlobals:
+    """Async variants of TestTemplateGlobals."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, async_environment):
+        setup_globals(async_environment)
+        yield
+        async_environment.globals.pop("render_block", None)
+        async_environment.globals.pop("render_blocks", None)
+
+    @pytest.mark.asyncio
+    async def test_async_render_block_global(self, async_environment, get_html):
+        """Test single-block rendering via async template global."""
+        template = async_environment.get_template("include_block.html.jinja2")
+        rendered = await template.render_async(lucky_number=LUCKY_NUMBER)
+        assert rendered == get_html("include_block.html")
+
+    @pytest.mark.asyncio
+    async def test_async_render_blocks_global(self, async_environment, get_html):
+        """Test multi-block rendering via async template global."""
+        template = async_environment.get_template("include_blocks.html.jinja2")
+        rendered = await template.render_async(name=NAME, lucky_number=LUCKY_NUMBER)
+        assert rendered == get_html("include_blocks.html")
+
+    @pytest.mark.asyncio
+    async def test_async_auto_context_forwarding(self, async_environment, get_html):
+        """Test that parent context is forwarded in async mode."""
+        template = async_environment.get_template(
+            "include_block_auto_context.html.jinja2"
+        )
+        rendered = await template.render_async(lucky_number=LUCKY_NUMBER)
+        assert rendered == get_html("include_block_auto_context.html")
+
+    @pytest.mark.asyncio
+    async def test_async_kwargs_override_context(self, async_environment, get_html):
+        """Test that kwargs override parent context in async mode."""
+        template = async_environment.get_template(
+            "include_block_override.html.jinja2"
+        )
+        rendered = await template.render_async(lucky_number=LUCKY_NUMBER)
+        assert rendered == get_html("include_block_override.html")
 
 
 class TestBlockNotFoundError:

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -119,6 +119,7 @@ class TestAsyncTemplateGlobals:
         rendered = await template.render_async(lucky_number=LUCKY_NUMBER)
         assert rendered == get_html("include_block_override.html")
 
+
 class TestSetupGlobals:
     @pytest.mark.parametrize("fixture_name", ["environment", "async_environment"])
     def test_preserves_existing_globals(self, fixture_name, request):

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -115,9 +115,7 @@ class TestAsyncTemplateGlobals:
     @pytest.mark.asyncio
     async def test_async_kwargs_override_context(self, async_environment, get_html):
         """Test that kwargs override parent context in async mode."""
-        template = async_environment.get_template(
-            "include_block_override.html.jinja2"
-        )
+        template = async_environment.get_template("include_block_override.html.jinja2")
         rendered = await template.render_async(lucky_number=LUCKY_NUMBER)
         assert rendered == get_html("include_block_override.html")
 

--- a/tests/test_render_block.py
+++ b/tests/test_render_block.py
@@ -119,6 +119,35 @@ class TestAsyncTemplateGlobals:
         rendered = await template.render_async(lucky_number=LUCKY_NUMBER)
         assert rendered == get_html("include_block_override.html")
 
+class TestSetupGlobals:
+    @pytest.mark.parametrize("fixture_name", ["environment", "async_environment"])
+    def test_preserves_existing_globals(self, fixture_name, request):
+        """setup_globals should not clobber user-defined globals."""
+        environment = request.getfixturevalue(fixture_name)
+        sentinel_render_block = object()
+        sentinel_render_blocks = object()
+
+        original_render_block = environment.globals.get("render_block")
+        original_render_blocks = environment.globals.get("render_blocks")
+
+        environment.globals["render_block"] = sentinel_render_block
+        environment.globals["render_blocks"] = sentinel_render_blocks
+
+        try:
+            setup_globals(environment)
+            assert environment.globals["render_block"] is sentinel_render_block
+            assert environment.globals["render_blocks"] is sentinel_render_blocks
+        finally:
+            if original_render_block is None:
+                environment.globals.pop("render_block", None)
+            else:
+                environment.globals["render_block"] = original_render_block
+
+            if original_render_blocks is None:
+                environment.globals.pop("render_blocks", None)
+            else:
+                environment.globals["render_blocks"] = original_render_blocks
+
 
 class TestBlockNotFoundError:
     def test_exception_message(self):


### PR DESCRIPTION
## Summary

Implements the feature requested in #47 — the ability to call `render_block()` and `render_blocks()` from within Jinja2 template expressions.

This enables templates to compose fragments from other template files, which is especially useful for HTMX patterns:

```jinja2
<div id="customer">
  {{ render_block("customer/edit.html.jinja2", "customer", customer=invoice.customer) }}
</div>
```

## Changes

### Core (`src/jinja2_fragments/__init__.py`)
- Added four `@pass_context`-decorated callables (sync/async × single/multi block) that merge the current template context with caller-supplied kwargs and return `Markup` to avoid double-escaping
- Added `setup_globals(environment)` public helper that installs the correct sync or async pair as `environment.globals["render_block"]` and `environment.globals["render_blocks"]`

### Tests (`tests/test_render_block.py`)
- `TestTemplateGlobals`: sync single-block, multi-block, auto context forwarding, kwargs override
- `TestAsyncTemplateGlobals`: async equivalents of all the above
- 4 new test templates + 4 expected output files

### Documentation
- New "Rendering Blocks from Within Templates" section in `basic_usage.rst`
- `setup_globals` added to autodoc in `api/core.rst`

Closes #47

---

_Conversation: https://app.warp.dev/conversation/b8d2c614-aba8-44b5-8009-8f832c3ec255_
_Run: https://oz.warp.dev/runs/019d50fa-97f1-764a-99ac-549e5af62bc2_
_Plans:_
- _[Add render_block/render_blocks Jinja2 template globals](https://app.warp.dev/drive/notebook/zwg1iGohe2AWLwQGejAXdM)_

_This PR was generated with [Oz](https://warp.dev/oz)._

## Summary by Sourcery

Add Jinja2 template globals for rendering blocks from within templates and document their usage.

New Features:
- Expose render_block and render_blocks as Jinja2 template globals via a setup_globals helper that configures sync or async callables based on the environment.

Enhancements:
- Ensure template-global renderers automatically forward the current Jinja2 context while allowing explicit kwargs to override it, and return Markup to prevent double-escaping.

Documentation:
- Document rendering blocks from within templates in basic usage docs and add setup_globals to the public API reference.

Tests:
- Add sync and async test suites and fixtures covering render_block/render_blocks template globals, context forwarding, and kwargs overriding behavior.